### PR TITLE
fix: [spearbit-97] Prevent createAccount() user error

### DIFF
--- a/test/factory/MultiOwnerMSCAFactoryTest.t.sol
+++ b/test/factory/MultiOwnerMSCAFactoryTest.t.sol
@@ -37,11 +37,7 @@ contract MultiOwnerMSCAFactoryTest is Test {
         multiOwnerPlugin = new MultiOwnerPlugin();
         bytes32 manifestHash = keccak256(abi.encode(multiOwnerPlugin.pluginManifest()));
         factory = new MultiOwnerMSCAFactory(
-            address(this), 
-            address(multiOwnerPlugin), 
-            impl, 
-            manifestHash, 
-            IEntryPoint(address(entryPoint))
+            address(this), address(multiOwnerPlugin), impl, manifestHash, IEntryPoint(address(entryPoint))
         );
         vm.deal(address(this), 100 ether);
     }
@@ -89,18 +85,18 @@ contract MultiOwnerMSCAFactoryTest is Test {
 
     function test_badOwnersArray() public {
         vm.expectRevert(MultiOwnerMSCAFactory.OwnersArrayEmpty.selector);
-        factory.createAccount(0, new address[](0));
+        factory.getAddress(0, new address[](0));
 
         address[] memory badOwners = new address[](2);
 
         vm.expectRevert(MultiOwnerMSCAFactory.ZeroAddressOwner.selector);
-        factory.createAccount(0, badOwners);
+        factory.getAddress(0, badOwners);
 
         badOwners[0] = address(1);
         badOwners[1] = address(1);
 
         vm.expectRevert(MultiOwnerMSCAFactory.DuplicateOwner.selector);
-        factory.createAccount(0, badOwners);
+        factory.getAddress(0, badOwners);
     }
 
     function test_addStake() public {

--- a/test/factory/MultiOwnerTokenReceiverFactoryTest.t.sol
+++ b/test/factory/MultiOwnerTokenReceiverFactoryTest.t.sol
@@ -54,11 +54,11 @@ contract MultiOwnerTokenReceiverMSCAFactoryTest is Test {
         bytes32 ownerManifestHash = keccak256(abi.encode(multiOwnerPlugin.pluginManifest()));
         bytes32 tokenReceiverManifestHash = keccak256(abi.encode(tokenReceiverPlugin.pluginManifest()));
         factory = new MultiOwnerTokenReceiverMSCAFactory(
-            address(this), 
-            address(multiOwnerPlugin), 
+            address(this),
+            address(multiOwnerPlugin),
             address(tokenReceiverPlugin),
-            impl, 
-            ownerManifestHash, 
+            impl,
+            ownerManifestHash,
             tokenReceiverManifestHash,
             IEntryPoint(address(entryPoint))
         );


### PR DESCRIPTION
## Motivation

Factory's getAddress does not revert on invalid inputs to MultiOwnerPlugin which might potentially be a footgun for users/devs

## Solution

Add these checks into getAddress in the 2 factories