### PR TITLE
fix: [spearbit-25] Function initialize() can use calldata

### DIFF
--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -96,7 +96,7 @@ contract UpgradeableModularAccount is
     // EXTERNAL FUNCTIONS
 
     /// @inheritdoc IAccountInitializable
-    function initialize(address[] memory plugins, bytes calldata pluginInitData) external initializer {
+    function initialize(address[] calldata plugins, bytes calldata pluginInitData) external initializer {
         (bytes32[] memory manifestHashes, bytes[] memory pluginInstallDatas) =
             abi.decode(pluginInitData, (bytes32[], bytes[]));
 


### PR DESCRIPTION
Spearbit issue: https://github.com/spearbit-audits/alchemy-nov-review/issues/25