### PR TITLE
fix: Reorder CI elements to run `forge fmt` on the correct code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,6 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
-      - run: forge install
-
-      - run: forge fmt --check
 
       - name: "Check out the repo"
         uses: "actions/checkout@v3"
@@ -42,6 +39,10 @@ jobs:
 
       - name: "Install the Node.js dependencies"
         run: "pnpm install"
+
+      - run: forge install
+
+      - run: forge fmt --check
 
       - name: "Lint the contracts"
         run: "pnpm lint"


### PR DESCRIPTION
## Motivation

I'm not 100% sure, but I think our CI is running `forge fmt` before checkout out our code. If it is, that would explain why some of the changes to `forge fmt` haven't caused CI issues when the changes were rolled out, only locally.

## Solution

Reorder the steps in the linting CI to run `forge fmt` after checking out and installing the repo