### PR TITLE
fix: [spearbit-51][quantstamp-14] clean up upper bits of address in PluginStorageLib

### DIFF
--- a/src/libraries/PluginStorageLib.sol
+++ b/src/libraries/PluginStorageLib.sol
@@ -31,6 +31,8 @@ library PluginStorageLib {
             mstore(0x40, add(add(key, totalSize), 32))
             mstore(key, totalSize)
 
+            // Clear any dirty upper bits of address
+            addr := and(addr, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
             // Store the address and batch index in the key buffer
             mstore(add(key, 32), addr)
             mstore(add(key, 64), batchIndex)


### PR DESCRIPTION
[ spearbit-51](https://github.com/spearbit-audits/alchemy-nov-review/issues/51) allocateAssociatedStorageKey() doesn't clear the upper bits of all parameters 

quantstamp-14 Certain Assumptions Are Made in the PluginStorageLib that Could Lead to Issues.