### PR TITLE
fix: [quantstamp-21] prevent adding IPlugin interface to account

### DIFF
--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -51,6 +51,7 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
     error ExecutionFunctionAlreadySet(bytes4 selector);
     error ExecutionFunctionNotSet(bytes4 selector);
     error IPluginFunctionNotAllowed(bytes4 selector);
+    error IPluginInterfaceNotAllowed();
     error InvalidDependenciesProvided();
     error InvalidPluginManifest();
     error MissingPluginDependency(address dependency);
@@ -591,7 +592,11 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
         // Add new interface ids the plugin enabled for the account
         length = manifest.interfaceIds.length;
         for (uint256 i = 0; i < length;) {
-            storage_.supportedInterfaces[manifest.interfaceIds[i]] += 1;
+            bytes4 interfaceId = manifest.interfaceIds[i];
+            if (interfaceId == type(IPlugin).interfaceId) {
+                revert IPluginInterfaceNotAllowed();
+            }
+            storage_.supportedInterfaces[interfaceId] += 1;
             unchecked {
                 ++i;
             }

--- a/test/account/UpgradeableModularAccountPluginManager.t.sol
+++ b/test/account/UpgradeableModularAccountPluginManager.t.sol
@@ -286,6 +286,25 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         });
     }
 
+    function test_installPlugin_failIfAddingIPluginInterfaceId() public {
+        vm.startPrank(owner2);
+
+        PluginManifest memory manifestBad;
+        manifestBad.interfaceIds = new bytes4[](1);
+        manifestBad.interfaceIds[0] = type(IPlugin).interfaceId;
+        MockPlugin mockPluginBad = new MockPlugin(manifestBad);
+        bytes32 manifestHashBad = keccak256(abi.encode(mockPluginBad.pluginManifest()));
+
+        vm.expectRevert(PluginManagerInternals.IPluginInterfaceNotAllowed.selector);
+        IPluginManager(account2).installPlugin({
+            plugin: address(mockPluginBad),
+            manifestHash: manifestHashBad,
+            pluginInitData: bytes(""),
+            dependencies: new FunctionReference[](0),
+            injectedHooks: new IPluginManager.InjectedHook[](0)
+        });
+    }
+
     function test_installPlugin_failWtihErc4337FunctionSelector() public {
         vm.startPrank(owner2);
 


### PR DESCRIPTION
MSCA-21
Plugins May Add the IPlugin Interface to MSCA

Update: Revert if a plugin tries to do this.

https://github.com/spearbit-audits/alchemy-nov-review/issues/17