### PR TITLE
fix: [spearbit-83] [quantstamp-12] revert  in session key permissions preExecHook when function Id not matched

### DIFF
--- a/src/plugins/session/permissions/SessionKeyPermissionsPlugin.sol
+++ b/src/plugins/session/permissions/SessionKeyPermissionsPlugin.sol
@@ -118,8 +118,9 @@ contract SessionKeyPermissionsPlugin is ISessionKeyPermissionsPlugin, SessionKey
     {
         if (functionId == uint8(FunctionId.PRE_EXECUTION_HOOK_UPDATE_LIMITS)) {
             _updateLimitsPreExec(msg.sender, data);
+        } else {
+            revert NotImplemented();
         }
-        return "";
     }
 
     /// @inheritdoc BasePlugin


### PR DESCRIPTION
https://github.com/spearbit-audits/alchemy-nov-review/issues/83 

MSCA-12
Non-Reverting Execution Hooks In Case Of No functionId Matc