### PR TITLE
fix: [quantstamp-15] only support executeWithSessionKey method in session key permission hooks

### DIFF
--- a/src/plugins/session/permissions/SessionKeyPermissionsPlugin.sol
+++ b/src/plugins/session/permissions/SessionKeyPermissionsPlugin.sol
@@ -247,9 +247,9 @@ contract SessionKeyPermissionsPlugin is ISessionKeyPermissionsPlugin, SessionKey
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
     /// @dev A pre user op validation hook that checks the permissions of the key used to validate the user op.
-    function _checkUserOpPermissions(UserOperation calldata userOp) internal returns (uint256 validationRes) {
-        // if not calling executeWithSessionKey, nothing to do.
-        if (bytes4(userOp.callData) != ISessionKeyPlugin.executeWithSessionKey.selector) return validationRes;
+    function _checkUserOpPermissions(UserOperation calldata userOp) internal returns (uint256) {
+        // If not calling executeWithSessionKey, nothing to do. Return 0 as validation success.
+        if (bytes4(userOp.callData) != ISessionKeyPlugin.executeWithSessionKey.selector) return 0;
 
         // Decode the executions array and the session key from the user op's calldata
         (Call[] memory calls, address sessionKey) = abi.decode(userOp.callData[4:], (Call[], address));
@@ -330,7 +330,7 @@ contract SessionKeyPermissionsPlugin is ISessionKeyPermissionsPlugin, SessionKey
         // otherwise a packed struct of the aggregator address (0 here), and two
         // 6-byte timestamps indicating the start and end times at which the op
         // is valid.
-        validationRes = uint160(!validationSuccess ? 1 : 0) | (uint256(sessionKeyData.validUntil) << 160)
+        return uint160(!validationSuccess ? 1 : 0) | (uint256(sessionKeyData.validUntil) << 160)
             | (uint256(currentValidAfter) << (208));
     }
 
@@ -368,7 +368,7 @@ contract SessionKeyPermissionsPlugin is ISessionKeyPermissionsPlugin, SessionKey
 
     /// @dev Runs as a pre exec hook, and updates the spend limits of the session key in use
     function _updateLimitsPreExec(address account, bytes calldata callData) internal {
-        // if not calling executeWithSessionKey, nothing to do.
+        // If not calling executeWithSessionKey, nothing to do.
         if (bytes4(callData) != ISessionKeyPlugin.executeWithSessionKey.selector) return;
 
         (Call[] memory calls, address sessionKey) = abi.decode(callData[4:], (Call[], address));


### PR DESCRIPTION
MSCA-15
Missing Validation for Execution Function in SessionKeyPermissionsPlugin Hooks

For the second portion of the recommendation.
> However, even if the function selector is validated in the pre-execution hook, the plugin still cannot ensure that the hook is not triggered by a random plugin via the executeFromPlugin() call. Checking whether the sender supports the IPlugin interface does not fully solve the
issue since the sender can manipulate the return values of the supportsInterface() call. A possible mitigation is to add a flag that indicates whether the call to the hook is triggered via executeFromPlugin() or not.

If a plugin is authorized to call `executeWithSessionKey`, therefore passes the validations and hook checks, then updating limit for the session key is fine. No fix needed here.