### PR TITLE
fix: [spearbit-29] remove redundant SSTOREs

### DIFF
--- a/src/libraries/AssociatedLinkedListSetLib.sol
+++ b/src/libraries/AssociatedLinkedListSetLib.sol
@@ -188,9 +188,6 @@ library AssociatedLinkedListSetLib {
             _store(cursorSlot, bytes32(0));
             cursor = next;
         } while (!isSentinel(cursor) && cursor != bytes32(0));
-
-        StoragePointer sentinelSlot = _mapLookup(keyBuffer, SENTINEL_VALUE);
-        _store(sentinelSlot, bytes32(0));
     }
 
     /// @notice Set the flags on a value in the set.

--- a/src/libraries/LinkedListSetLib.sol
+++ b/src/libraries/LinkedListSetLib.sol
@@ -124,8 +124,6 @@ library LinkedListSetLib {
             map[cursor] = bytes32(0);
             cursor = next;
         } while (!isSentinel(cursor) && cursor != bytes32(0));
-
-        map[SENTINEL_VALUE] = bytes32(0);
     }
 
     /// @notice Set the flags on a value in the set.


### PR DESCRIPTION
Spearbit-29
Redundant `SSTORE`s in `clear()`