### PR TITLE
fix: [spearbit-43] simplify `tryRemoveKnown()`

### DIFF
--- a/src/libraries/AssociatedLinkedListSetLib.sol
+++ b/src/libraries/AssociatedLinkedListSetLib.sol
@@ -164,9 +164,9 @@ library AssociatedLinkedListSetLib {
         }
 
         // Need to do:
-        // map[prev] = clearFlags(next) | getUserFlags(currentValue) | (next & HAS_NEXT_FLAG);
+        // map[prev] = clearUserFlags(next) | getUserFlags(currentValue);
         // map[unwrappedKey] = bytes32(0);
-        _store(prevSlot, clearFlags(next) | getUserFlags(currentValue) | (next & HAS_NEXT_FLAG));
+        _store(prevSlot, clearUserFlags(next) | getUserFlags(currentValue));
         _store(valueSlot, bytes32(0));
 
         return true;

--- a/src/libraries/LinkedListSetLib.sol
+++ b/src/libraries/LinkedListSetLib.sol
@@ -107,7 +107,7 @@ library LinkedListSetLib {
             return false;
         }
 
-        map[prev] = clearFlags(next) | getUserFlags(currentValue) | (next & HAS_NEXT_FLAG);
+        map[prev] = clearUserFlags(next) | getUserFlags(currentValue);
         map[unwrappedKey] = bytes32(0);
         return true;
     }


### PR DESCRIPTION
Spearbit-43
Function `tryRemoveKnown()` does redundant operations

Update: following the suggestion, replace `clearFlags` with `clearUserFlags` and remove the extra operation.