### PR TITLE
fix: [spearbit-107] [quantstamp-22] use memory safe  revert instead in AccountExecutor

### DIFF
--- a/src/account/AccountExecutor.sol
+++ b/src/account/AccountExecutor.sol
@@ -93,8 +93,9 @@ abstract contract AccountExecutor {
             )
             case 0 {
                 // Bubble up the revert if the call reverts.
-                returndatacopy(0, 0, returndatasize())
-                revert(0, returndatasize())
+                let m := mload(0x40)
+                returndatacopy(m, 0x00, returndatasize())
+                revert(m, returndatasize())
             }
             default {
                 // Otherwise, we return the first word of the return data as the validation data

--- a/test/plugin/session/SessionKeyPluginWithMultiOwner.t.sol
+++ b/test/plugin/session/SessionKeyPluginWithMultiOwner.t.sol
@@ -279,8 +279,7 @@ contract SessionKeyPluginWithMultiOwnerTest is Test {
     function testFuzz_sessionKey_userOpValidation_invalidSig(uint8 sessionKeysSeed, uint64 signerSeed) public {
         _createSessionKeys(sessionKeysSeed);
 
-        (address signer, uint256 signerPrivate) =
-            makeAddrAndKey(string.concat("Signer", vm.toString(uint32(signerSeed))));
+        (address signer,) = makeAddrAndKey(string.concat("Signer", vm.toString(uint32(signerSeed))));
 
         // The signer should not be a session key of the plugin - this is exceedingly unlikely but checking
         // anyways.
@@ -310,7 +309,7 @@ contract SessionKeyPluginWithMultiOwnerTest is Test {
 
         vm.prank(address(account1));
         vm.expectRevert(abi.encodeWithSelector(ISessionKeyPlugin.InvalidSignature.selector, signer));
-        uint256 result = sessionKeyPlugin.userOpValidationFunction(
+        sessionKeyPlugin.userOpValidationFunction(
             uint8(ISessionKeyPlugin.FunctionId.USER_OP_VALIDATION_SESSION_KEY), userOp, userOpHash
         );
     }


### PR DESCRIPTION
Follow up on https://github.com/alchemyplatform/modular-account/pull/46

https://github.com/spearbit-audits/alchemy-nov-review/issues/107 

MSCA-22 SIG_VALIDATION_FAILED Returned in Incorrect Cases