### PR TITLE
chore: remove pinned foundry version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-02292f2d2caa547968bd039c06dc53d98b72bf39
 
       - name: "Install Pnpm"
         uses: "pnpm/action-setup@v2"
@@ -71,8 +69,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-02292f2d2caa547968bd039c06dc53d98b72bf39
 
       - name: Install forge dependencies
         run: forge install
@@ -94,8 +90,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-02292f2d2caa547968bd039c06dc53d98b72bf39
 
       - name: Install forge dependencies
         run: forge install


### PR DESCRIPTION
To unblock CI tests. Nightly versions are purged arbitrarily, causing our CI to fail.

I chose to remove the pinned version to always download the latest version, which I don't feel great about, but I felt that it was the better choice than pinning an older version. If we pin to an older (hopefully less ephemeral) version, that would undo the recent formatting changes to the contracts, and force the team to stay on an older version of foundry. There are also no guarantees at the moment that the older version would stick around, too.

When we get more guidance from the Foundry team, I'll revisit this. I definitely want to pin the version at some point and keep our local environments and CI in sync.

