### PR TITLE
fix: [spearbit-47] add evm version=paris in config

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 solc = '0.8.21'
-evm_version="paris"
+evm_version='paris'
 via_ir = true
 src = 'src'
 out = 'out'
@@ -20,13 +20,14 @@ depth = 10
 
 [profile.optimized-build]
 via_ir = true
+evm_version='paris'
 script = 'src'
 test = 'src'
 out = 'out-optimized'
 
 [profile.lite]
 solc = '0.8.21'
-evm_version="paris"
+evm_version='paris'
 via_ir = false
 optimizer = true
 optimizer_runs = 10_000
@@ -34,10 +35,12 @@ ignored_error_codes = []
 
 [profile.deep.fuzz]
 runs = 10000
+evm_version='paris'
 
 [profile.deep.invariant]
 runs = 5000
 depth = 32
+evm_version='paris'
 
 [fmt]
 line_length = 115


### PR DESCRIPTION
## Motivation

Note: foundry has default evm version as paris already. This just makes it obvious and maximally safe
https://github.com/spearbit-audits/alchemy-nov-review/issues/47
