### PR TITLE
fix: [spearbit-61] standardize index variable init

### DIFF
--- a/src/plugins/owner/MultiOwnerPlugin.sol
+++ b/src/plugins/owner/MultiOwnerPlugin.sol
@@ -411,7 +411,7 @@ contract MultiOwnerPlugin is BasePlugin, IMultiOwnerPlugin, IERC1271 {
         address[] memory ownersToRemove
     ) private {
         uint256 length = ownersToRemove.length;
-        for (uint256 i; i < length;) {
+        for (uint256 i = 0; i < length;) {
             if (!ownerSet.tryRemove(associated, CastLib.toSetValue(ownersToRemove[i]))) {
                 revert OwnerDoesNotExist(ownersToRemove[i]);
             }
@@ -429,7 +429,7 @@ contract MultiOwnerPlugin is BasePlugin, IMultiOwnerPlugin, IERC1271 {
     {
         address[] memory owners_ = ownersOf(associated);
         uint256 length = owners_.length;
-        for (uint256 i; i < length;) {
+        for (uint256 i = 0; i < length;) {
             if (SignatureChecker.isValidERC1271SignatureNow(owners_[i], digest, signature)) {
                 return true;
             }


### PR DESCRIPTION
## Motivation

standardize initializing index variable. we do `uint i = 0` everywhere except in these 2 locations

https://github.com/spearbit-audits/alchemy-nov-review/issues/61