### PR TITLE
fix: [quanstamp-req] Contract data key

### DIFF
--- a/src/plugins/session/permissions/SessionKeyPermissionsBase.sol
+++ b/src/plugins/session/permissions/SessionKeyPermissionsBase.sol
@@ -80,7 +80,7 @@ abstract contract SessionKeyPermissionsBase is ISessionKeyPlugin {
 
     // ContractData (128 bytes)
     // 12 padding zeros || associated address || CONTRACT_DATA_PREFIX || batch index || sessionKeyId
-    // || contractAddress  || 12 padding zero bytes
+    // || 12 padding zero bytes || contractAddress
 
     // FunctionData (128 bytes)
     // 12 padding zeros || associated address || FUNCTION_DATA_PREFIX || batch index || sessionKeyId || selector
@@ -154,7 +154,7 @@ abstract contract SessionKeyPermissionsBase is ISessionKeyPlugin {
             PluginStorageLib.allocateAssociatedStorageKey(associated, prefixAndBatchIndex, 2);
 
         bytes32 contractDataKey1 = SessionKeyId.unwrap(id);
-        bytes32 contractDataKey2 = bytes32(bytes20(contractAddress));
+        bytes32 contractDataKey2 = bytes32(uint256(uint160(contractAddress)));
         return _toContractData(
             PluginStorageLib.associatedStorageLookup(associatedStorageKey, contractDataKey1, contractDataKey2)
         );


### PR DESCRIPTION
## Motivation

The Quanstamp audit team suggested rearranging the bit-alignment of the key to `ContractData` in `SessionKeyPermissionsBase` for consistency with other key definitions.

## Solution

Changing the comment describing the key layout:
 - From `// 12 padding zeros || associated address || CONTRACT_DATA_PREFIX || batch index || sessionKeyId || contractAddress  || 12 padding zero bytes`
 - Back to `// 12 padding zeros || associated address || CONTRACT_DATA_PREFIX || batch index || sessionKeyId || 12 padding zero bytes || contractAddress`

Changing the calculation of `contractDataKey2`:
 - From `bytes32(bytes20(contractAddress))`
 - To `bytes32(uint256(uint160(contractAddress)))`