### PR TITLE
fix: [spearbit-16] Use _assertNotNullFunction in `_addHooks`

### DIFF
--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -224,10 +224,8 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                 }
             }
         } else {
-            if (postExecHook == FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE) {
-                // both pre and post hooks cannot be null
-                revert NullFunctionReference();
-            }
+            // both pre and post hooks cannot be null
+            _assertNotNullFunction(postExecHook);
 
             if (!hooks.postOnlyHooks.tryIncrement(CastLib.toSetValue(postExecHook))) {
                 revert DuplicateHookLimitExceeded(selector, postExecHook);


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

https://github.com/spearbit-audits/alchemy-nov-review/issues/16

## Solution

Call the internal function `_assertNotNullFunction` to perform the same check.