### PR TITLE
fix: [spearbit-37] Add event emission to MultiOwnerPlugin install/uninstall

### DIFF
--- a/src/plugins/owner/MultiOwnerPlugin.sol
+++ b/src/plugins/owner/MultiOwnerPlugin.sol
@@ -189,10 +189,14 @@ contract MultiOwnerPlugin is BasePlugin, IMultiOwnerPlugin, IERC1271 {
             revert EmptyOwnersNotAllowed();
         }
         _addOwnersOrRevert(_owners, msg.sender, initialOwners);
+
+        emit OwnerUpdated(msg.sender, initialOwners, new address[](0));
     }
 
     /// @inheritdoc BasePlugin
     function onUninstall(bytes calldata) external override {
+        address[] memory ownersToRemove = ownersOf(msg.sender);
+        emit OwnerUpdated(msg.sender, new address[](0), ownersToRemove);
         _owners.clear(msg.sender);
     }
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

https://github.com/spearbit-audits/alchemy-nov-review/issues/37

## Solution

Add event emissions to `_onInstall` and `onUninstall` that show the ownership changes made.

Update tests to expect these event emissions.