### PR TITLE
fix: [spearbit-28] Simplify storage access syntax of executeFromPluginExternal

### DIFF
--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -292,12 +292,15 @@ contract UpgradeableModularAccount is
         //
         // We allow calls where the data may be less than 4 bytes - it's up to the calling contract to
         // determine how to handle this.
+
+        PermittedExternalCallData storage permittedExternalCallData =
+            storage_.permittedExternalCalls[IPlugin(callingPlugin)][target];
+
         bool isTargetCallPermitted;
-        if (storage_.permittedExternalCalls[IPlugin(callingPlugin)][target].addressPermitted) {
+        if (permittedExternalCallData.addressPermitted) {
             isTargetCallPermitted = (
-                storage_.permittedExternalCalls[IPlugin(callingPlugin)][target].anySelectorPermitted
-                    || data.length == 0
-                    || storage_.permittedExternalCalls[IPlugin(callingPlugin)][target].permittedSelectors[bytes4(data)]
+                permittedExternalCallData.anySelectorPermitted || data.length == 0
+                    || permittedExternalCallData.permittedSelectors[bytes4(data)]
             );
         } else {
             isTargetCallPermitted = storage_.pluginData[callingPlugin].anyExternalAddressPermitted;


### PR DESCRIPTION
## Motivation

https://github.com/spearbit-audits/alchemy-nov-review/issues/28

## Solution

Simplify the storage access syntax of `PermittedExternalCallData` in `executeFromPluginExternal` to use a storage pointer var first, rather than repeating the mapping lookup expression.

Verified that this has minimal impact on gas costs using `forge snapshot`, it looks like both this and the previous syntax are getting correctly pulled out into a single `sload` by the optimizer. There is a small variability in gas due to this change, but it is around 10-15 gas in either direction so I'm not too concerned.