### PR TITLE
fix: [spearbit-26] Upgrade to solc 0.8.22 and remove explicit unchecked blocks for loop increments

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc = '0.8.21'
+solc = '0.8.22'
 evm_version='paris'
 via_ir = true
 src = 'src'
@@ -14,20 +14,16 @@ ignored_error_codes = []
 runs = 500
 
 [invariant]
-runs=500
+runs = 500
 fail_on_revert = true
 depth = 10
 
 [profile.optimized-build]
-via_ir = true
-evm_version='paris'
 script = 'src'
 test = 'src'
 out = 'out-optimized'
 
 [profile.lite]
-solc = '0.8.21'
-evm_version='paris'
 via_ir = false
 optimizer = true
 optimizer_runs = 10_000
@@ -35,12 +31,10 @@ ignored_error_codes = []
 
 [profile.deep.fuzz]
 runs = 10000
-evm_version='paris'
 
 [profile.deep.invariant]
 runs = 5000
 depth = 32
-evm_version='paris'
 
 [fmt]
 line_length = 115

--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -85,10 +85,9 @@ abstract contract AccountLoupe is IAccountLoupe, AccountStorageV1 {
         uint256 maxExecHooksLength = postOnlyExecHooksLength;
 
         // There can only be as many associated post hooks to run as there are pre hooks.
-        for (uint256 i = 0; i < preExecHooksLength;) {
+        for (uint256 i = 0; i < preExecHooksLength; ++i) {
             unchecked {
                 maxExecHooksLength += storedHooks.preHooks.getCount(CastLib.toSetValue(preExecHooks[i]));
-                ++i;
             }
         }
 
@@ -96,19 +95,18 @@ abstract contract AccountLoupe is IAccountLoupe, AccountStorageV1 {
         execHooks = new ExecutionHooks[](maxExecHooksLength);
         uint256 actualExecHooksLength = 0;
 
-        for (uint256 i = 0; i < preExecHooksLength;) {
+        for (uint256 i = 0; i < preExecHooksLength; ++i) {
             FunctionReference[] memory associatedPostExecHooks =
                 CastLib.toFunctionReferenceArray(storedHooks.associatedPostHooks[preExecHooks[i]].getAll());
             uint256 associatedPostExecHooksLength = associatedPostExecHooks.length;
 
             if (associatedPostExecHooksLength > 0) {
-                for (uint256 j = 0; j < associatedPostExecHooksLength;) {
+                for (uint256 j = 0; j < associatedPostExecHooksLength; ++j) {
                     execHooks[actualExecHooksLength].preExecHook = preExecHooks[i];
                     execHooks[actualExecHooksLength].postExecHook = associatedPostExecHooks[j];
 
                     unchecked {
                         ++actualExecHooksLength;
-                        ++j;
                     }
                 }
             } else {
@@ -118,18 +116,13 @@ abstract contract AccountLoupe is IAccountLoupe, AccountStorageV1 {
                     ++actualExecHooksLength;
                 }
             }
-
-            unchecked {
-                ++i;
-            }
         }
 
-        for (uint256 i = 0; i < postOnlyExecHooksLength;) {
+        for (uint256 i = 0; i < postOnlyExecHooksLength; ++i) {
             execHooks[actualExecHooksLength].postExecHook = postOnlyExecHooks[i];
 
             unchecked {
                 ++actualExecHooksLength;
-                ++i;
             }
         }
 

--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -355,7 +355,7 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
             revert InvalidDependenciesProvided();
         }
 
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             // Check the dependency interface id over the address of the dependency.
             (address dependencyAddr,) = dependencies[i].unpack();
 
@@ -371,32 +371,20 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
 
             // Increment the dependency's dependents counter.
             storage_.pluginData[dependencyAddr].dependentCount += 1;
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Update components according to the manifest.
 
         // Install execution functions
         length = manifest.executionFunctions.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             _setExecutionFunction(manifest.executionFunctions[i], plugin);
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Add installed plugin and selectors this plugin can call
         length = manifest.permittedExecutionSelectors.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             _enableExecFromPlugin(manifest.permittedExecutionSelectors[i], plugin, storage_);
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Add the permitted external calls to the account.
@@ -405,7 +393,7 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
         } else {
             // Only store the specific permitted external calls if "permit any" flag was not set.
             length = manifest.permittedExternalCalls.length;
-            for (uint256 i = 0; i < length;) {
+            for (uint256 i = 0; i < length; ++i) {
                 ManifestExternalCallPermission memory externalCallPermission = manifest.permittedExternalCalls[i];
 
                 PermittedExternalCallData storage permittedExternalCallData =
@@ -417,17 +405,9 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     permittedExternalCallData.anySelectorPermitted = true;
                 } else {
                     uint256 externalContractSelectorsLength = externalCallPermission.selectors.length;
-                    for (uint256 j = 0; j < externalContractSelectorsLength;) {
+                    for (uint256 j = 0; j < externalContractSelectorsLength; ++j) {
                         permittedExternalCallData.permittedSelectors[externalCallPermission.selectors[j]] = true;
-
-                        unchecked {
-                            ++j;
-                        }
                     }
-                }
-
-                unchecked {
-                    ++i;
                 }
             }
         }
@@ -439,7 +419,7 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
         assembly ("memory-safe") {
             sstore(injectedHooksArray.slot, length)
         }
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             InjectedHook memory hook = injectedHooks[i];
 
             // Check that the dependency is installed. This also blocks self-dependencies.
@@ -466,15 +446,11 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     ? FunctionReferenceLib.pack(hook.providingPlugin, hook.injectedHooksInfo.postExecHookFunctionId)
                     : FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Add user operation validation functions
         length = manifest.userOpValidationFunctions.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mv = manifest.userOpValidationFunctions[i];
             _addUserOpValidationFunction(
                 mv.executionSelector,
@@ -482,15 +458,11 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     mv.associatedFunction, plugin, dependencies, ManifestAssociatedFunctionType.NONE
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Add runtime validation functions
         length = manifest.runtimeValidationFunctions.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mv = manifest.runtimeValidationFunctions[i];
             _addRuntimeValidationFunction(
                 mv.executionSelector,
@@ -501,15 +473,11 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     ManifestAssociatedFunctionType.RUNTIME_VALIDATION_ALWAYS_ALLOW
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Add pre user operation validation hooks
         length = manifest.preUserOpValidationHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mh = manifest.preUserOpValidationHooks[i];
             _addPreUserOpValidationHook(
                 mh.executionSelector,
@@ -520,15 +488,11 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Add pre runtime validation hooks
         length = manifest.preRuntimeValidationHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mh = manifest.preRuntimeValidationHooks[i];
             _addPreRuntimeValidationHook(
                 mh.executionSelector,
@@ -539,14 +503,11 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY
                 )
             );
-            unchecked {
-                ++i;
-            }
         }
 
         // Add pre and post execution hooks
         length = manifest.executionHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestExecutionHook memory mh = manifest.executionHooks[i];
             _addExecHooks(
                 mh.executionSelector,
@@ -557,15 +518,11 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     mh.postExecHook, plugin, dependencies, ManifestAssociatedFunctionType.NONE
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Add pre and post permitted call hooks
         length = manifest.permittedCallHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             _addPermittedCallHooks(
                 manifest.permittedCallHooks[i].executionSelector,
                 plugin,
@@ -582,23 +539,16 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     ManifestAssociatedFunctionType.NONE
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Add new interface ids the plugin enabled for the account
         length = manifest.interfaceIds.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             bytes4 interfaceId = manifest.interfaceIds[i];
             if (interfaceId == type(IPlugin).interfaceId) {
                 revert IPluginInterfaceNotAllowed();
             }
             storage_.supportedInterfaces[interfaceId] += 1;
-            unchecked {
-                ++i;
-            }
         }
 
         // Add the plugin metadata to the account
@@ -612,7 +562,7 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
 
         // Call injected hooks' onHookApply after all setup, this is before calling plugin onInstall
         length = injectedHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             InjectedHook memory hook = injectedHooks[i];
 
             /* solhint-disable no-empty-blocks */
@@ -625,10 +575,6 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
 
             // zero out hookApplyData to reduce log cost
             injectedHooks[i].hookApplyData = new bytes(0);
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Initialize the plugin storage for the account.
@@ -668,16 +614,12 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
         // Remove this plugin as a dependent from its dependencies.
         FunctionReference[] memory dependencies = pluginData.dependencies;
         uint256 length = dependencies.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             FunctionReference dependency = dependencies[i];
             (address dependencyAddr,) = dependency.unpack();
 
             // Decrement the dependent count for the dependency function.
             storage_.pluginData[dependencyAddr].dependentCount -= 1;
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Remove the plugin metadata from the account.
@@ -687,7 +629,7 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
 
         // Remove pre and post permitted call hooks
         length = args.manifest.permittedCallHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             _removePermittedCallHooks(
                 args.manifest.permittedCallHooks[i].executionSelector,
                 args.plugin,
@@ -704,15 +646,11 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     ManifestAssociatedFunctionType.NONE
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Remove pre and post execution function hooks
         length = args.manifest.executionHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestExecutionHook memory mh = args.manifest.executionHooks[i];
             _removeExecHooks(
                 mh.executionSelector,
@@ -723,15 +661,11 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     mh.postExecHook, args.plugin, dependencies, ManifestAssociatedFunctionType.NONE
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Remove pre runtime validation function hooks
         length = args.manifest.preRuntimeValidationHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mh = args.manifest.preRuntimeValidationHooks[i];
 
             _removePreRuntimeValidationHook(
@@ -743,15 +677,11 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Remove pre user op validation function hooks
         length = args.manifest.preUserOpValidationHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             ManifestAssociatedFunction memory mh = args.manifest.preUserOpValidationHooks[i];
 
             _removePreUserOpValidationHook(
@@ -763,34 +693,22 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     ManifestAssociatedFunctionType.PRE_HOOK_ALWAYS_DENY
                 )
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Remove runtime validation function hooks
         length = args.manifest.runtimeValidationFunctions.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             bytes4 executionSelector = args.manifest.runtimeValidationFunctions[i].executionSelector;
             storage_.selectorData[executionSelector].runtimeValidation =
                 FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE;
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Remove user op validation function hooks
         length = args.manifest.userOpValidationFunctions.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             bytes4 executionSelector = args.manifest.userOpValidationFunctions[i].executionSelector;
             storage_.selectorData[executionSelector].userOpValidation =
                 FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE;
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Remove permitted external call permissions, anyExternalAddressPermitted is cleared when pluginData being
@@ -798,7 +716,7 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
         if (!args.manifest.permitAnyExternalAddress) {
             // Only clear the specific permitted external calls if "permit any" flag was not set.
             length = args.manifest.permittedExternalCalls.length;
-            for (uint256 i = 0; i < length;) {
+            for (uint256 i = 0; i < length; ++i) {
                 ManifestExternalCallPermission memory externalCallPermission =
                     args.manifest.permittedExternalCalls[i];
 
@@ -812,24 +730,16 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     permittedExternalCallData.anySelectorPermitted = false;
                 } else {
                     uint256 externalContractSelectorsLength = externalCallPermission.selectors.length;
-                    for (uint256 j = 0; j < externalContractSelectorsLength;) {
+                    for (uint256 j = 0; j < externalContractSelectorsLength; ++j) {
                         permittedExternalCallData.permittedSelectors[externalCallPermission.selectors[j]] = false;
-
-                        unchecked {
-                            ++j;
-                        }
                     }
-                }
-
-                unchecked {
-                    ++i;
                 }
             }
         }
 
         // Remove injected hooks
         length = pluginData.injectedHooks.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             StoredInjectedHook memory hook = pluginData.injectedHooks[i];
 
             // Decrement the dependent count for the plugin providing the hook.
@@ -843,41 +753,25 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                     ? FunctionReferenceLib.pack(hook.providingPlugin, hook.postExecHookFunctionId)
                     : FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Remove permitted account execution function call permissions
         length = args.manifest.permittedExecutionSelectors.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             storage_.permittedCalls[_getPermittedCallKey(args.plugin, args.manifest.permittedExecutionSelectors[i])]
                 .callPermitted = false;
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Remove installed execution function
         length = args.manifest.executionFunctions.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             storage_.selectorData[args.manifest.executionFunctions[i]].plugin = address(0);
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Decrease supported interface ids' counters
         length = args.manifest.interfaceIds.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             storage_.supportedInterfaces[args.manifest.interfaceIds[i]] -= 1;
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Call onHookUnapply on all injected hooks
@@ -887,7 +781,7 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
         if (hasUnapplyHookData && hookUnapplyData.length != length) {
             revert ArrayLengthMismatch();
         }
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             StoredInjectedHook memory hook = pluginData.injectedHooks[i];
 
             /* solhint-disable no-empty-blocks */
@@ -907,10 +801,6 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
                 emit PluginIgnoredHookUnapplyCallbackFailure(args.plugin, hook.providingPlugin);
             }
             /* solhint-enable no-empty-blocks */
-
-            unchecked {
-                ++i;
-            }
         }
 
         // Clear the plugin storage for the account.

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -109,14 +109,10 @@ contract UpgradeableModularAccount is
         FunctionReference[] memory emptyDependencies = new FunctionReference[](0);
         InjectedHook[] memory emptyInjectedHooks = new InjectedHook[](0);
 
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             _installPlugin(
                 plugins[i], manifestHashes[i], pluginInstallDatas[i], emptyDependencies, emptyInjectedHooks
             );
-
-            unchecked {
-                ++i;
-            }
         }
 
         emit ModularAccountInitialized(_ENTRY_POINT);
@@ -210,12 +206,8 @@ contract UpgradeableModularAccount is
         uint256 callsLength = calls.length;
         results = new bytes[](callsLength);
 
-        for (uint256 i = 0; i < callsLength;) {
+        for (uint256 i = 0; i < callsLength; ++i) {
             results[i] = _exec(calls[i].target, calls[i].value, calls[i].data);
-
-            unchecked {
-                ++i;
-            }
         }
 
         _postNativeFunction(postExecHooks, postHookArgs);
@@ -453,7 +445,7 @@ contract UpgradeableModularAccount is
             );
 
             preUserOpValidationHooksLength = preUserOpValidationHooks.length;
-            for (uint256 i = 0; i < preUserOpValidationHooksLength;) {
+            for (uint256 i = 0; i < preUserOpValidationHooksLength; ++i) {
                 // FunctionReference preUserOpValidationHook = preUserOpValidationHooks[i];
 
                 if (preUserOpValidationHooks[i].isEmptyOrMagicValue()) {
@@ -474,10 +466,6 @@ contract UpgradeableModularAccount is
                     revert UnexpectedAggregator(plugin, functionId, address(uint160(currentValidationData)));
                 }
                 validationData = _coalescePreValidation(validationData, currentValidationData);
-
-                unchecked {
-                    ++i;
-                }
             }
         }
 
@@ -518,7 +506,7 @@ contract UpgradeableModularAccount is
             );
 
             uint256 preRuntimeValidationHooksLength = preRuntimeValidationHooks.length;
-            for (uint256 i = 0; i < preRuntimeValidationHooksLength;) {
+            for (uint256 i = 0; i < preRuntimeValidationHooksLength; ++i) {
                 FunctionReference preRuntimeValidationHook = preRuntimeValidationHooks[i];
 
                 if (preRuntimeValidationHook.isEmptyOrMagicValue()) {
@@ -532,10 +520,6 @@ contract UpgradeableModularAccount is
                 _updatePluginCallBufferFunctionId(callBuffer, functionId);
 
                 _executeRuntimePluginFunction(callBuffer, plugin, PreRuntimeValidationHookFailed.selector);
-
-                unchecked {
-                    ++i;
-                }
             }
         }
 
@@ -739,7 +723,7 @@ contract UpgradeableModularAccount is
         }
         _updatePluginCallBufferSelector(callBuffer, IPlugin.preExecutionHook.selector);
 
-        for (uint256 i = 0; i < preExecHooksLength;) {
+        for (uint256 i = 0; i < preExecHooksLength; ++i) {
             FunctionReference preExecHook = preHooks[i];
 
             if (preExecHook.isEmptyOrMagicValue()) {
@@ -763,10 +747,6 @@ contract UpgradeableModularAccount is
             if (postHooks[adjustedIndex].length > 0) {
                 hookReturnData[adjustedIndex] = abi.decode(_collectReturnData(), (bytes));
             }
-
-            unchecked {
-                ++i;
-            }
         }
     }
 
@@ -787,7 +767,7 @@ contract UpgradeableModularAccount is
             // We don't need to run each associated post-hook in reverse order, because the associativity we want
             // to maintain is reverse order of associated pre-hooks.
             uint256 postHooksToRunLength = postHooksToRun.length;
-            for (uint256 j = 0; j < postHooksToRunLength;) {
+            for (uint256 j = 0; j < postHooksToRunLength; ++j) {
                 (address plugin, uint8 functionId) = postHooksToRun[j].unpack();
 
                 // Execute the post hook with the current post hook args
@@ -796,12 +776,10 @@ contract UpgradeableModularAccount is
                 catch (bytes memory revertReason) {
                     revert PostExecHookReverted(plugin, functionId, revertReason);
                 }
-
-                unchecked {
-                    ++j;
-                }
             }
 
+            // Solidity v0.8.22 allows the optimizer to automatically remove checking on for loop increments, but
+            // not decrements. Therefore we need to use unchecked here to avoid the extra costs for checked math.
             unchecked {
                 --i;
             }
@@ -823,7 +801,7 @@ contract UpgradeableModularAccount is
         uint256 startingIndex
     ) internal view {
         uint256 preExecHooksLength = preExecHooks.length;
-        for (uint256 i = 0; i < preExecHooksLength;) {
+        for (uint256 i = 0; i < preExecHooksLength; ++i) {
             FunctionReference preExecHook = preExecHooks[i];
 
             // If the pre-exec hook has associated post hooks, cache them in the postHooks array.
@@ -834,10 +812,6 @@ contract UpgradeableModularAccount is
             }
             // In no-associated-post-hooks case, we're OK returning the default value, which is an array of length
             // 0.
-
-            unchecked {
-                ++i;
-            }
         }
     }
 

--- a/src/helpers/FactoryHelpers.sol
+++ b/src/helpers/FactoryHelpers.sol
@@ -7,15 +7,11 @@ library FactoryHelpers {
     /// @return bool if the owners array is valid
     function isValidOwnerArray(address[] calldata owners) internal pure returns (bool) {
         address currentOwnerValue;
-        for (uint256 i = 0; i < owners.length;) {
+        for (uint256 i = 0; i < owners.length; ++i) {
             if (owners[i] <= currentOwnerValue) {
                 return false;
             }
             currentOwnerValue = owners[i];
-
-            unchecked {
-                ++i;
-            }
         }
         return true;
     }

--- a/src/libraries/AssociatedLinkedListSetLib.sol
+++ b/src/libraries/AssociatedLinkedListSetLib.sol
@@ -382,16 +382,12 @@ library AssociatedLinkedListSetLib {
         keyBuffer = _allocateTempKeyBuffer(set, associated);
 
         cursor = SENTINEL_VALUE;
-        for (uint256 i = 0; i < count;) {
+        for (uint256 i = 0; i < count; ++i) {
             StoragePointer cursorSlot = _mapLookup(keyBuffer, cursor);
             bytes32 cursorValue = _load(cursorSlot);
             bytes32 cleared = clearFlags(cursorValue);
             res[i] = SetValue.wrap(bytes30(cleared));
             cursor = cleared;
-
-            unchecked {
-                ++i;
-            }
         }
     }
 

--- a/src/libraries/CastLib.sol
+++ b/src/libraries/CastLib.sol
@@ -26,12 +26,8 @@ library CastLib {
         }
 
         uint256 length = values.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             valuesBytes[i] >>= 96;
-
-            unchecked {
-                i++;
-            }
         }
 
         assembly ("memory-safe") {

--- a/src/plugins/owner/MultiOwnerPlugin.sol
+++ b/src/plugins/owner/MultiOwnerPlugin.sol
@@ -373,14 +373,10 @@ contract MultiOwnerPlugin is BasePlugin, IMultiOwnerPlugin, IERC1271 {
         address[] memory ownersToAdd
     ) private {
         uint256 length = ownersToAdd.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             // Catches address(0), duplicated addresses
             if (!ownerSet.tryAdd(associated, CastLib.toSetValue(ownersToAdd[i]))) {
                 revert InvalidOwner(ownersToAdd[i]);
-            }
-
-            unchecked {
-                ++i;
             }
         }
     }
@@ -391,13 +387,9 @@ contract MultiOwnerPlugin is BasePlugin, IMultiOwnerPlugin, IERC1271 {
         address[] memory ownersToRemove
     ) private {
         uint256 length = ownersToRemove.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             if (!ownerSet.tryRemove(associated, CastLib.toSetValue(ownersToRemove[i]))) {
                 revert OwnerDoesNotExist(ownersToRemove[i]);
-            }
-
-            unchecked {
-                ++i;
             }
         }
     }
@@ -409,13 +401,9 @@ contract MultiOwnerPlugin is BasePlugin, IMultiOwnerPlugin, IERC1271 {
     {
         address[] memory owners_ = ownersOf(associated);
         uint256 length = owners_.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             if (SignatureChecker.isValidERC1271SignatureNow(owners_[i], digest, signature)) {
                 return true;
-            }
-
-            unchecked {
-                ++i;
             }
         }
         return false;

--- a/src/plugins/session/SessionKeyPlugin.sol
+++ b/src/plugins/session/SessionKeyPlugin.sol
@@ -86,14 +86,10 @@ contract SessionKeyPlugin is ISessionKeyPlugin, SessionKeyPermissions, BasePlugi
         // Unset the key id for all session keys.
         address[] memory sessionKeys = CastLib.toAddressArray(_sessionKeys.getAll(msg.sender));
         uint256 length = sessionKeys.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             _updateSessionKeyId(msg.sender, sessionKeys[i], SessionKeyId.wrap(bytes32(0)));
 
             emit SessionKeyRemoved(msg.sender, sessionKeys[i]);
-
-            unchecked {
-                ++i;
-            }
         }
 
         _sessionKeys.clear(msg.sender);
@@ -116,14 +112,10 @@ contract SessionKeyPlugin is ISessionKeyPlugin, SessionKeyPermissions, BasePlugi
         uint256 callsLength = calls.length;
         bytes[] memory results = new bytes[](callsLength);
 
-        for (uint256 i = 0; i < callsLength;) {
+        for (uint256 i = 0; i < callsLength; ++i) {
             Call calldata call = calls[i];
 
             results[i] = IPluginExecutor(msg.sender).executeFromPluginExternal(call.target, call.value, call.data);
-
-            unchecked {
-                ++i;
-            }
         }
 
         return results;
@@ -214,16 +206,12 @@ contract SessionKeyPlugin is ISessionKeyPlugin, SessionKeyPermissions, BasePlugi
 
         uint256 length = sessionKeys.length;
         bytes32 predecessor = SENTINEL_VALUE;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             if (sessionKeys[i] == sessionKey) {
                 return predecessor;
             }
 
             predecessor = bytes32(bytes20(sessionKeys[i]));
-
-            unchecked {
-                ++i;
-            }
         }
 
         revert SessionKeyNotFound(sessionKey);
@@ -372,14 +360,10 @@ contract SessionKeyPlugin is ISessionKeyPlugin, SessionKeyPermissions, BasePlugi
         address[] memory sessionKeysToAdd = abi.decode(data, (address[]));
 
         uint256 length = sessionKeysToAdd.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             // Use the public function to add the session key, set the key id, and emit the event.
             // Note that no tags are set when adding keys with this method.
             addSessionKey(sessionKeysToAdd[i], bytes32(0));
-
-            unchecked {
-                ++i;
-            }
         }
     }
 

--- a/src/plugins/session/permissions/SessionKeyPermissions.sol
+++ b/src/plugins/session/permissions/SessionKeyPermissions.sol
@@ -25,12 +25,8 @@ abstract contract SessionKeyPermissions is ISessionKeyPlugin, SessionKeyPermissi
         (SessionKeyData storage sessionKeyData, SessionKeyId keyId) = _loadSessionKey(msg.sender, sessionKey);
 
         uint256 length = updates.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ++i) {
             _performSessionKeyPermissionsUpdate(keyId, sessionKeyData, updates[i]);
-
-            unchecked {
-                ++i;
-            }
         }
 
         emit PermissionsUpdated(msg.sender, sessionKey, updates);
@@ -71,15 +67,11 @@ abstract contract SessionKeyPermissions is ISessionKeyPlugin, SessionKeyPermissi
         bool validationSuccess = callsLength > 0;
         {
             ContractAccessControlType accessControlType = sessionKeyData.contractAccessControlType;
-            for (uint256 i = 0; i < callsLength;) {
+            for (uint256 i = 0; i < callsLength; ++i) {
                 Call memory call = calls[i];
                 nativeTokenSpend += call.value;
                 validationSuccess =
                     validationSuccess && _checkCallPermissions(accessControlType, keyId, call.target, call.data);
-
-                unchecked {
-                    ++i;
-                }
             }
         }
 
@@ -182,7 +174,7 @@ abstract contract SessionKeyPermissions is ISessionKeyPlugin, SessionKeyPermissi
         SessionKeyId keyId = _sessionKeyIdOf(msg.sender, sessionKey);
         SessionKeyData storage sessionKeyData = _sessionKeyDataOf(msg.sender, keyId);
 
-        for (uint256 i = 0; i < callsLength;) {
+        for (uint256 i = 0; i < callsLength; ++i) {
             Call memory call = calls[i];
             newNativeTokenUsage += call.value;
 
@@ -199,10 +191,6 @@ abstract contract SessionKeyPermissions is ISessionKeyPlugin, SessionKeyPermissi
                 ) {
                     revert ERC20SpendLimitExceeded(msg.sender, sessionKey, call.target);
                 }
-            }
-
-            unchecked {
-                ++i;
             }
         }
 


### PR DESCRIPTION
## Motivation

https://github.com/spearbit-audits/alchemy-nov-review/issues/26

We can reduce LOC, and improve readability and maintainability, by upgrding to `solc` 0.8.22, which automatically removes checked math on most for loop increments.

## Solution

Upgrade to `solc` 0.8.22.

Move loop increments from an `unchecked {...}` block at the end of the loop to the update step within the `for` expression.
 - Verified that this does not change gas costs using `forge snapshot`.

Also removed duplicate statements in `foundry.toml`, where profiles re-declared identical variables to what was inherited from the default profile.