### PR TITLE
fix: [spearbit-48] Collapse if/else in SessionKeyPermissionsLoupe

### DIFF
--- a/src/plugins/session/permissions/SessionKeyPermissionsLoupe.sol
+++ b/src/plugins/session/permissions/SessionKeyPermissionsLoupe.sol
@@ -103,10 +103,9 @@ abstract contract SessionKeyPermissionsLoupe is SessionKeyPermissionsBase {
     {
         (SessionKeyData storage sessionKeyData,) = _loadSessionKey(account, sessionKey);
 
-        bool hasLimit = sessionKeyData.hasGasLimit;
         shouldReset = sessionKeyData.gasLimitResetThisBundle;
 
-        if (hasLimit) {
+        if (sessionKeyData.hasGasLimit) {
             info.hasLimit = true;
             info.limit = sessionKeyData.gasLimit.limitAmount;
             info.limitUsed = sessionKeyData.gasLimit.limitUsed;


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

https://github.com/spearbit-audits/alchemy-nov-review/issues/48

## Solution

Perform the recommended fix of removing the `else` branch and returning the default values in the struct when the limit is not set.