### PR TITLE
fix: [spearbit-69] reorder functions and update comments in plugins to be consistent

### DIFF
--- a/src/plugins/owner/MultiOwnerPlugin.sol
+++ b/src/plugins/owner/MultiOwnerPlugin.sol
@@ -147,36 +147,6 @@ contract MultiOwnerPlugin is BasePlugin, IMultiOwnerPlugin, IERC1271 {
         return _1271_MAGIC_VALUE_FAILURE;
     }
 
-    // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-    // ┃    Plugin view functions    ┃
-    // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-
-    /// @inheritdoc IMultiOwnerPlugin
-    function encodeMessageData(address account, bytes memory message)
-        public
-        view
-        override
-        returns (bytes memory)
-    {
-        bytes32 messageHash = keccak256(abi.encode(ERC6900_TYPEHASH, keccak256(message)));
-        return abi.encodePacked("\x19\x01", _domainSeparator(account), messageHash);
-    }
-
-    /// @inheritdoc IMultiOwnerPlugin
-    function getMessageHash(address account, bytes memory message) public view override returns (bytes32) {
-        return keccak256(encodeMessageData(account, message));
-    }
-
-    /// @inheritdoc IMultiOwnerPlugin
-    function isOwnerOf(address account, address ownerToCheck) public view returns (bool) {
-        return _owners.contains(account, CastLib.toSetValue(ownerToCheck));
-    }
-
-    /// @inheritdoc IMultiOwnerPlugin
-    function ownersOf(address account) public view returns (address[] memory) {
-        return CastLib.toAddressArray(_owners.getAll(account));
-    }
-
     // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
     // ┃    Plugin interface functions    ┃
     // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
@@ -363,9 +333,39 @@ contract MultiOwnerPlugin is BasePlugin, IMultiOwnerPlugin, IERC1271 {
         return interfaceId == type(IMultiOwnerPlugin).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    // ┏━━━━━━━━━━━━━━━┓
-    // ┃   Internal    ┃
-    // ┗━━━━━━━━━━━━━━━┛
+    // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    // ┃    Plugin only view functions    ┃
+    // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+    /// @inheritdoc IMultiOwnerPlugin
+    function isOwnerOf(address account, address ownerToCheck) public view returns (bool) {
+        return _owners.contains(account, CastLib.toSetValue(ownerToCheck));
+    }
+
+    /// @inheritdoc IMultiOwnerPlugin
+    function ownersOf(address account) public view returns (address[] memory) {
+        return CastLib.toAddressArray(_owners.getAll(account));
+    }
+
+    /// @inheritdoc IMultiOwnerPlugin
+    function encodeMessageData(address account, bytes memory message)
+        public
+        view
+        override
+        returns (bytes memory)
+    {
+        bytes32 messageHash = keccak256(abi.encode(ERC6900_TYPEHASH, keccak256(message)));
+        return abi.encodePacked("\x19\x01", _domainSeparator(account), messageHash);
+    }
+
+    /// @inheritdoc IMultiOwnerPlugin
+    function getMessageHash(address account, bytes memory message) public view override returns (bytes32) {
+        return keccak256(encodeMessageData(account, message));
+    }
+
+    // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    // ┃    Internal Functions    ┃
+    // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
     function _domainSeparator(address account) internal view returns (bytes32) {
         return keccak256(abi.encode(_TYPE_HASH, _HASHED_NAME, _HASHED_VERSION, block.chainid, account, _SALT));

--- a/src/plugins/session/ISessionKeyPlugin.sol
+++ b/src/plugins/session/ISessionKeyPlugin.sol
@@ -97,9 +97,9 @@ interface ISessionKeyPlugin {
     /// @param updates The abi-encoded updates to perform.
     function updateKeyPermissions(address sessionKey, bytes[] calldata updates) external;
 
-    // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-    // ┃    Plugin-only function    ┃
-    // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+    // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    // ┃    Plugin only state updating functions       ┃
+    // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
     /// @notice An externally available function, callable by anyone, that resets the "last used" timestamp on a
     /// session key. This helps a session key get "unstuck" if it was used in a setting where every call it made
@@ -109,9 +109,9 @@ interface ISessionKeyPlugin {
     /// @param sessionKey The session key to reset.
     function resetSessionKeyGasLimitTimestamp(address account, address sessionKey) external;
 
-    // ┏━━━━━━━━━━━━━━━━━━━━━━┓
-    // ┃    View functions    ┃
-    // ┗━━━━━━━━━━━━━━━━━━━━━━┛
+    // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    // ┃    Plugin only view functions    ┃
+    // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
     /// @notice Get the session keys of the account.
     /// This function is not added to accounts during installation.

--- a/src/plugins/session/permissions/SessionKeyPermissionsLoupe.sol
+++ b/src/plugins/session/permissions/SessionKeyPermissionsLoupe.sol
@@ -5,6 +5,10 @@ import {ISessionKeyPlugin} from "../ISessionKeyPlugin.sol";
 import {SessionKeyPermissionsBase} from "./SessionKeyPermissionsBase.sol";
 
 abstract contract SessionKeyPermissionsLoupe is SessionKeyPermissionsBase {
+    // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    // ┃    Plugin only view functions    ┃
+    // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
     /// @inheritdoc ISessionKeyPlugin
     function getAccessControlType(address account, address sessionKey)
         external


### PR DESCRIPTION
https://github.com/spearbit-audits/alchemy-nov-review/issues/69

All plugins functions are now following the below function order.
```
     // ┃ Execution functions    ┃
     // ┃ Plugin only state updating functions   ┃
     // ┃ Execution view functions   ┃
     // ┃ Plugin interface functions    ┃
     // ┃ EIP-165   ┃
     // ┃ Plugin only view functions    ┃
     // ┃ Internal    ┃
```