### PR TITLE
fix: [spearbit-77] Refactor session key loading util functions

### DIFF
--- a/src/plugins/session/permissions/SessionKeyPermissions.sol
+++ b/src/plugins/session/permissions/SessionKeyPermissions.sol
@@ -22,7 +22,7 @@ abstract contract SessionKeyPermissions is ISessionKeyPlugin, SessionKeyPermissi
 
     /// @inheritdoc ISessionKeyPlugin
     function updateKeyPermissions(address sessionKey, bytes[] calldata updates) public override {
-        (SessionKeyData storage sessionKeyData, SessionKeyId keyId) = _loadSessionKey(msg.sender, sessionKey);
+        (SessionKeyData storage sessionKeyData, SessionKeyId keyId) = _loadSessionKeyData(msg.sender, sessionKey);
 
         uint256 length = updates.length;
         for (uint256 i = 0; i < length; ++i) {
@@ -34,7 +34,7 @@ abstract contract SessionKeyPermissions is ISessionKeyPlugin, SessionKeyPermissi
 
     /// @inheritdoc ISessionKeyPlugin
     function resetSessionKeyGasLimitTimestamp(address account, address sessionKey) external override {
-        (SessionKeyData storage sessionKeyData,) = _loadSessionKey(account, sessionKey);
+        (SessionKeyData storage sessionKeyData,) = _loadSessionKeyData(account, sessionKey);
         if (sessionKeyData.gasLimitResetThisBundle) {
             sessionKeyData.gasLimitResetThisBundle = false;
             sessionKeyData.gasLimitTimeInfo.lastUsed = uint48(block.timestamp);

--- a/src/plugins/session/permissions/SessionKeyPermissionsLoupe.sol
+++ b/src/plugins/session/permissions/SessionKeyPermissionsLoupe.sol
@@ -11,7 +11,7 @@ abstract contract SessionKeyPermissionsLoupe is SessionKeyPermissionsBase {
         view
         returns (ContractAccessControlType)
     {
-        (SessionKeyData storage sessionKeyData,) = _loadSessionKey(account, sessionKey);
+        (SessionKeyData storage sessionKeyData,) = _loadSessionKeyData(account, sessionKey);
         return sessionKeyData.contractAccessControlType;
     }
 
@@ -21,8 +21,7 @@ abstract contract SessionKeyPermissionsLoupe is SessionKeyPermissionsBase {
         view
         returns (bool isOnList, bool checkSelectors)
     {
-        SessionKeyId keyId = _sessionKeyIdOf(account, sessionKey);
-        _assertKeyExists(keyId, sessionKey);
+        SessionKeyId keyId = _loadSessionKeyId(account, sessionKey);
         ContractData storage contractData = _contractDataOf(account, keyId, contractAddress);
         return (contractData.isOnList, contractData.checkSelectors);
     }
@@ -34,8 +33,7 @@ abstract contract SessionKeyPermissionsLoupe is SessionKeyPermissionsBase {
         address contractAddress,
         bytes4 selector
     ) external view returns (bool isOnList) {
-        SessionKeyId keyId = _sessionKeyIdOf(account, sessionKey);
-        _assertKeyExists(keyId, sessionKey);
+        SessionKeyId keyId = _loadSessionKeyId(account, sessionKey);
         FunctionData storage functionData = _functionDataOf(account, keyId, contractAddress, selector);
         return functionData.isOnList;
     }
@@ -46,7 +44,7 @@ abstract contract SessionKeyPermissionsLoupe is SessionKeyPermissionsBase {
         view
         returns (uint48 validAfter, uint48 validUntil)
     {
-        (SessionKeyData storage sessionKeyData,) = _loadSessionKey(account, sessionKey);
+        (SessionKeyData storage sessionKeyData,) = _loadSessionKeyData(account, sessionKey);
         return (sessionKeyData.validAfter, sessionKeyData.validUntil);
     }
 
@@ -56,7 +54,7 @@ abstract contract SessionKeyPermissionsLoupe is SessionKeyPermissionsBase {
         view
         returns (SpendLimitInfo memory)
     {
-        (SessionKeyData storage sessionKeyData,) = _loadSessionKey(account, sessionKey);
+        (SessionKeyData storage sessionKeyData,) = _loadSessionKeyData(account, sessionKey);
 
         bool hasLimit = !sessionKeyData.nativeTokenSpendLimitBypassed;
 
@@ -80,7 +78,7 @@ abstract contract SessionKeyPermissionsLoupe is SessionKeyPermissionsBase {
         view
         returns (SpendLimitInfo memory)
     {
-        (, SessionKeyId keyId) = _loadSessionKey(account, sessionKey);
+        SessionKeyId keyId = _loadSessionKeyId(account, sessionKey);
         ContractData storage tokenContractData = _contractDataOf(account, keyId, token);
         return SpendLimitInfo({
             hasLimit: tokenContractData.isERC20WithSpendLimit,
@@ -93,9 +91,7 @@ abstract contract SessionKeyPermissionsLoupe is SessionKeyPermissionsBase {
 
     /// @inheritdoc ISessionKeyPlugin
     function getRequiredPaymaster(address account, address sessionKey) external view returns (address) {
-        SessionKeyId id = _sessionKeyIdOf(account, sessionKey);
-        _assertKeyExists(id, sessionKey);
-        SessionKeyData storage sessionKeyData = _sessionKeyDataOf(account, id);
+        (SessionKeyData storage sessionKeyData,) = _loadSessionKeyData(account, sessionKey);
         return sessionKeyData.hasRequiredPaymaster ? sessionKeyData.requiredPaymaster : address(0);
     }
 
@@ -106,7 +102,7 @@ abstract contract SessionKeyPermissionsLoupe is SessionKeyPermissionsBase {
         override
         returns (SpendLimitInfo memory, bool)
     {
-        (SessionKeyData storage sessionKeyData,) = _loadSessionKey(account, sessionKey);
+        (SessionKeyData storage sessionKeyData,) = _loadSessionKeyData(account, sessionKey);
 
         bool hasLimit = sessionKeyData.hasGasLimit;
         bool shouldReset = sessionKeyData.gasLimitResetThisBundle;


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

https://github.com/spearbit-audits/alchemy-nov-review/issues/77

## Solution

Add the recommended function to load a session key id and assert that it exists, renamed to `_loadSessionKeyId`.

Apply the recommended change to `getRequiredPaymaster`.

For clarity given the new function name, rename the previous function `_loadSessionKey` to `_loadSessionKeyData`.

Use the new `_loadSessionKeyId` function in place of previous instances of `_sessionKeyIdOf` + `_assertKeyExists`.
 - With all of these changes applied, the only usage of `_assertKeyExists` is within `_loadSessionKeyId`, so inline the function there instead.