### PR TITLE
fix: [spearbit-40] Evaluate keccak expressions at compile time when possible

### DIFF
--- a/src/libraries/AccountStorageV1.sol
+++ b/src/libraries/AccountStorageV1.sol
@@ -86,6 +86,7 @@ contract AccountStorageV1 {
     /// bytes = keccak256(
     ///     abi.encode(uint256(keccak256("Alchemy.UpgradeableModularAccount.Storage_V1")) - 1)
     /// ) & ~bytes32(uint256(0xff));
+    /// This cannot be evaluated at compile time because of its use in inline assembly.
     bytes32 internal constant _V1_STORAGE_SLOT = 0xade46bbfcf6f898a43d541e42556d456ca0bf9b326df8debc0f29d3f811a0300;
 
     function _getAccountStorage() internal pure returns (AccountStorage storage storage_) {

--- a/src/libraries/AssociatedLinkedListSetLib.sol
+++ b/src/libraries/AssociatedLinkedListSetLib.sol
@@ -25,6 +25,7 @@ library AssociatedLinkedListSetLib {
     // Mapping keys exclude the upper 15 bits of the meta bytes, which allows keys to be either a value or the
     // sentinel.
 
+    // This cannot be evaluated at compile time because of its use in inline assembly.
     bytes4 internal constant _ASSOCIATED_STORAGE_PREFIX = 0xf938c976; // bytes4(keccak256("AssociatedLinkedListSet"))
 
     // A custom type representing the index of a storage slot

--- a/src/plugins/owner/MultiOwnerPlugin.sol
+++ b/src/plugins/owner/MultiOwnerPlugin.sol
@@ -68,8 +68,7 @@ contract MultiOwnerPlugin is BasePlugin, IMultiOwnerPlugin, IERC1271 {
     bytes4 internal constant _1271_MAGIC_VALUE = 0x1626ba7e;
     bytes4 internal constant _1271_MAGIC_VALUE_FAILURE = 0xffffffff;
 
-    // keccak256("ERC6900Message(bytes message)");
-    bytes32 private constant ERC6900_TYPEHASH = 0xa856bbdae1f2c6e4aa17a75ad7cc5650f184ec4b549174dd7258c9701d663fc6;
+    bytes32 private constant MODULAR_ACCOUNT_TYPEHASH = keccak256("AlchemyModularAccountMessage(bytes message)");
 
     AssociatedLinkedListSet internal _owners;
 
@@ -356,7 +355,7 @@ contract MultiOwnerPlugin is BasePlugin, IMultiOwnerPlugin, IERC1271 {
         override
         returns (bytes memory)
     {
-        bytes32 messageHash = keccak256(abi.encode(ERC6900_TYPEHASH, keccak256(message)));
+        bytes32 messageHash = keccak256(abi.encode(MODULAR_ACCOUNT_TYPEHASH, keccak256(message)));
         return abi.encodePacked("\x19\x01", _domainSeparator(account), messageHash);
     }
 

--- a/src/plugins/session/permissions/SessionKeyPermissionsBase.sol
+++ b/src/plugins/session/permissions/SessionKeyPermissionsBase.sol
@@ -69,10 +69,10 @@ abstract contract SessionKeyPermissionsBase is ISessionKeyPlugin {
     }
 
     // Prefixes:
-    bytes4 internal constant SESSION_KEY_ID_PREFIX = bytes4(0x1a01dae4); // bytes4(keccak256("SessionKeyId"))
-    bytes4 internal constant SESSION_KEY_DATA_PREFIX = bytes4(0x16bff296); // bytes4(keccak256("SessionKeyData"))
-    bytes4 internal constant CONTRACT_DATA_PREFIX = bytes4(0x634c29f5); // bytes4(keccak256("ContractData"))
-    bytes4 internal constant FUNCTION_DATA_PREFIX = bytes4(0xd50536f0); // bytes4(keccak256("FunctionData"))
+    bytes4 internal constant SESSION_KEY_ID_PREFIX = bytes4(keccak256("SessionKeyId"));
+    bytes4 internal constant SESSION_KEY_DATA_PREFIX = bytes4(keccak256("SessionKeyData"));
+    bytes4 internal constant CONTRACT_DATA_PREFIX = bytes4(keccak256("ContractData"));
+    bytes4 internal constant FUNCTION_DATA_PREFIX = bytes4(keccak256("FunctionData"));
 
     // KEY DERIVATION
     // All of these following keys begin with the associated address,


### PR DESCRIPTION
## Motivation

https://github.com/spearbit-audits/alchemy-nov-review/issues/40

## Solution

Evaluate `keccak256` constants at compile time when possible, and when it is correctly inlined.

Add comments to cases where it can't be evaluated at compile time.

Also updates the ERC-712 typehash for `MultiOwnerPlugin` to reference modular account, rather than ERC-6900.