### PR TITLE
refactor: move FunctionReference type to IPluginManager

### DIFF
--- a/src/account/AccountLoupe.sol
+++ b/src/account/AccountLoupe.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.22;
 import {KnownSelectors} from "../helpers/KnownSelectors.sol";
 
 import {IAccountLoupe} from "../interfaces/IAccountLoupe.sol";
+import {FunctionReference} from "../interfaces/IPluginManager.sol";
 
 import {AccountStorageV1} from "../libraries/AccountStorageV1.sol";
 import {CastLib} from "../libraries/CastLib.sol";
 import {CountableLinkedListSetLib} from "../libraries/CountableLinkedListSetLib.sol";
-import {FunctionReference} from "../libraries/FunctionReferenceLib.sol";
 import {LinkedListSet, LinkedListSetLib} from "../libraries/LinkedListSetLib.sol";
 
 /// @title Account Loupe

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -17,12 +17,12 @@ import {IAccountView} from "../interfaces/IAccountView.sol";
 import {IEntryPoint} from "../interfaces/erc4337/IEntryPoint.sol";
 import {IPlugin, PluginManifest} from "../interfaces/IPlugin.sol";
 import {IPluginExecutor} from "../interfaces/IPluginExecutor.sol";
-import {IPluginManager} from "../interfaces/IPluginManager.sol";
+import {FunctionReference, IPluginManager} from "../interfaces/IPluginManager.sol";
 import {UserOperation} from "../interfaces/erc4337/UserOperation.sol";
 
 import {CastLib} from "../libraries/CastLib.sol";
 import {CountableLinkedListSetLib} from "../libraries/CountableLinkedListSetLib.sol";
-import {FunctionReference, FunctionReferenceLib} from "../libraries/FunctionReferenceLib.sol";
+import {FunctionReferenceLib} from "../libraries/FunctionReferenceLib.sol";
 import {LinkedListSet, LinkedListSetLib} from "../libraries/LinkedListSetLib.sol";
 import {UUPSUpgradeable} from "../../ext/UUPSUpgradeable.sol";
 
@@ -44,6 +44,7 @@ contract UpgradeableModularAccount is
 {
     using CountableLinkedListSetLib for LinkedListSet;
     using LinkedListSetLib for LinkedListSet;
+    using FunctionReferenceLib for FunctionReference;
 
     /// @dev Struct to hold optional configuration data for uninstalling a plugin. This should be encoded and
     /// passed to the `config` parameter of `uninstallPlugin`.
@@ -419,7 +420,7 @@ contract UpgradeableModularAccount is
         bytes32 userOpHash,
         bool doPreValidationHooks
     ) internal returns (uint256 validationData) {
-        if (userOpValidationFunction == FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE) {
+        if (userOpValidationFunction.isEmpty()) {
             revert UserOpValidationFunctionMissing(selector);
         }
 
@@ -518,7 +519,7 @@ contract UpgradeableModularAccount is
         {
             if (runtimeValidationFunction.isEmptyOrMagicValue()) {
                 if (
-                    runtimeValidationFunction == FunctionReferenceLib._EMPTY_FUNCTION_REFERENCE
+                    runtimeValidationFunction.isEmpty()
                         && (
                             (
                                 msg.sig != IPluginManager.installPlugin.selector

--- a/src/interfaces/IAccountLoupe.sol
+++ b/src/interfaces/IAccountLoupe.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.22;
 
-import {FunctionReference} from "../libraries/FunctionReferenceLib.sol";
+import {FunctionReference} from "./IPluginManager.sol";
 
 /// @title Account Loupe Interface
 interface IAccountLoupe {

--- a/src/interfaces/IPluginManager.sol
+++ b/src/interfaces/IPluginManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.22;
 
-import {FunctionReference} from "../libraries/FunctionReferenceLib.sol";
+type FunctionReference is bytes21;
 
 /// @title Plugin Manager Interface
 interface IPluginManager {

--- a/src/libraries/AccountStorageV1.sol
+++ b/src/libraries/AccountStorageV1.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.22;
 
 import {IPlugin} from "../interfaces/IPlugin.sol";
+import {FunctionReference} from "../interfaces/IPluginManager.sol";
 
-import {FunctionReference} from "../libraries/FunctionReferenceLib.sol";
 import {LinkedListSet} from "../libraries/LinkedListSetLib.sol";
 
 /// @title Account Storage V1

--- a/src/libraries/FunctionReferenceLib.sol
+++ b/src/libraries/FunctionReferenceLib.sol
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.22;
 
-type FunctionReference is bytes21;
-
-using {eq as ==, notEq as !=} for FunctionReference global;
-using FunctionReferenceLib for FunctionReference global;
+import {FunctionReference} from "../interfaces/IPluginManager.sol";
 
 /// @title Function Reference Lib
 /// @author Alchemy
@@ -30,12 +27,16 @@ library FunctionReferenceLib {
     function isEmptyOrMagicValue(FunctionReference fr) internal pure returns (bool) {
         return FunctionReference.unwrap(fr) <= bytes21(uint168(2));
     }
-}
 
-function eq(FunctionReference a, FunctionReference b) pure returns (bool) {
-    return FunctionReference.unwrap(a) == FunctionReference.unwrap(b);
-}
+    function isEmpty(FunctionReference fr) internal pure returns (bool) {
+        return FunctionReference.unwrap(fr) == bytes21(0);
+    }
 
-function notEq(FunctionReference a, FunctionReference b) pure returns (bool) {
-    return FunctionReference.unwrap(a) != FunctionReference.unwrap(b);
+    function eq(FunctionReference a, FunctionReference b) internal pure returns (bool) {
+        return FunctionReference.unwrap(a) == FunctionReference.unwrap(b);
+    }
+
+    function notEq(FunctionReference a, FunctionReference b) internal pure returns (bool) {
+        return FunctionReference.unwrap(a) != FunctionReference.unwrap(b);
+    }
 }

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -9,7 +9,8 @@ import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.so
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {MultiOwnerPlugin} from "../../src/plugins/owner/MultiOwnerPlugin.sol";
 import {IEntryPoint} from "../../src/interfaces/erc4337/IEntryPoint.sol";
-import {FunctionReference, FunctionReferenceLib} from "../../src/libraries/FunctionReferenceLib.sol";
+import {FunctionReference} from "../../src/interfaces/IPluginManager.sol";
+import {FunctionReferenceLib} from "../../src/libraries/FunctionReferenceLib.sol";
 import {
     IPlugin,
     ManifestExecutionHook,

--- a/test/account/AccountLoupe.t.sol
+++ b/test/account/AccountLoupe.t.sol
@@ -17,9 +17,9 @@ import {
     PluginManifest
 } from "../../src/interfaces/IPlugin.sol";
 import {IAccountLoupe} from "../../src/interfaces/IAccountLoupe.sol";
-import {IPluginManager} from "../../src/interfaces/IPluginManager.sol";
+import {FunctionReference, IPluginManager} from "../../src/interfaces/IPluginManager.sol";
 import {IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
-import {FunctionReference, FunctionReferenceLib} from "../../src/libraries/FunctionReferenceLib.sol";
+import {FunctionReferenceLib} from "../../src/libraries/FunctionReferenceLib.sol";
 
 import {MultiOwnerMSCAFactory} from "../../src/factory/MultiOwnerMSCAFactory.sol";
 import {ComprehensivePlugin} from "../mocks/plugins/ComprehensivePlugin.sol";

--- a/test/account/AccountPreValidationHooks.t.sol
+++ b/test/account/AccountPreValidationHooks.t.sol
@@ -11,7 +11,8 @@ import {IMultiOwnerPlugin} from "../../src/plugins/owner/IMultiOwnerPlugin.sol";
 import {MultiOwnerPlugin} from "../../src/plugins/owner/MultiOwnerPlugin.sol";
 import {IEntryPoint} from "../../src/interfaces/erc4337/IEntryPoint.sol";
 import {UserOperation} from "../../src/interfaces/erc4337/UserOperation.sol";
-import {FunctionReference, FunctionReferenceLib} from "../../src/libraries/FunctionReferenceLib.sol";
+import {FunctionReference} from "../../src/interfaces/IPluginManager.sol";
+import {FunctionReferenceLib} from "../../src/libraries/FunctionReferenceLib.sol";
 import {
     IPlugin,
     PluginManifest,

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -7,8 +7,8 @@ import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.so
 
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {IEntryPoint} from "../../src/interfaces/erc4337/IEntryPoint.sol";
+import {FunctionReference} from "../../src/interfaces/IPluginManager.sol";
 import {MultiOwnerPlugin} from "../../src/plugins/owner/MultiOwnerPlugin.sol";
-import {FunctionReference} from "../../src/libraries/FunctionReferenceLib.sol";
 import {Call} from "../../src/interfaces/IStandardExecutor.sol";
 
 import {

--- a/test/account/ExecuteFromPluginPermissions.t.sol
+++ b/test/account/ExecuteFromPluginPermissions.t.sol
@@ -8,8 +8,8 @@ import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.so
 import {IPlugin} from "../../src/interfaces/IPlugin.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {IEntryPoint} from "../../src/interfaces/erc4337/IEntryPoint.sol";
+import {FunctionReference} from "../../src/interfaces/IPluginManager.sol";
 import {MultiOwnerPlugin} from "../../src/plugins/owner/MultiOwnerPlugin.sol";
-import {FunctionReference} from "../../src/libraries/FunctionReferenceLib.sol";
 
 import {MultiOwnerMSCAFactory} from "../../src/factory/MultiOwnerMSCAFactory.sol";
 

--- a/test/account/ManifestValidity.t.sol
+++ b/test/account/ManifestValidity.t.sol
@@ -8,8 +8,8 @@ import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.so
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {PluginManagerInternals} from "../../src/account/PluginManagerInternals.sol";
 import {IEntryPoint} from "../../src/interfaces/erc4337/IEntryPoint.sol";
+import {FunctionReference} from "../../src/interfaces/IPluginManager.sol";
 import {MultiOwnerPlugin} from "../../src/plugins/owner/MultiOwnerPlugin.sol";
-import {FunctionReference} from "../../src/libraries/FunctionReferenceLib.sol";
 
 import {MultiOwnerMSCAFactory} from "../../src/factory/MultiOwnerMSCAFactory.sol";
 import {

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -18,9 +18,8 @@ import {IEntryPoint} from "../../src/interfaces/erc4337/IEntryPoint.sol";
 import {UserOperation} from "../../src/interfaces/erc4337/UserOperation.sol";
 import {IAccountInitializable} from "../../src/interfaces/IAccountInitializable.sol";
 import {IPlugin, PluginManifest} from "../../src/interfaces/IPlugin.sol";
-import {IPluginManager} from "../../src/interfaces/IPluginManager.sol";
+import {FunctionReference, IPluginManager} from "../../src/interfaces/IPluginManager.sol";
 import {Call} from "../../src/interfaces/IStandardExecutor.sol";
-import {FunctionReference} from "../../src/libraries/FunctionReferenceLib.sol";
 
 import {Counter} from "../mocks/Counter.sol";
 import {MultiOwnerMSCAFactory} from "../../src/factory/MultiOwnerMSCAFactory.sol";

--- a/test/account/UpgradeableModularAccountPluginManager.t.sol
+++ b/test/account/UpgradeableModularAccountPluginManager.t.sol
@@ -16,10 +16,10 @@ import {TokenReceiverPlugin} from "../../src/plugins/TokenReceiverPlugin.sol";
 import {IEntryPoint} from "../../src/interfaces/erc4337/IEntryPoint.sol";
 import {PluginManifest} from "../../src/interfaces/IPlugin.sol";
 import {IAccountLoupe} from "../../src/interfaces/IAccountLoupe.sol";
-import {IPluginManager} from "../../src/interfaces/IPluginManager.sol";
+import {FunctionReference, IPluginManager} from "../../src/interfaces/IPluginManager.sol";
 import {IStandardExecutor} from "../../src/interfaces/IStandardExecutor.sol";
 import {Call} from "../../src/interfaces/IStandardExecutor.sol";
-import {FunctionReference, FunctionReferenceLib} from "../../src/libraries/FunctionReferenceLib.sol";
+import {FunctionReferenceLib} from "../../src/libraries/FunctionReferenceLib.sol";
 import {IPlugin, PluginManifest} from "../../src/interfaces/IPlugin.sol";
 
 import {Counter} from "../mocks/Counter.sol";

--- a/test/account/ValidationIntersection.t.sol
+++ b/test/account/ValidationIntersection.t.sol
@@ -8,8 +8,8 @@ import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.so
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {IEntryPoint} from "../../src/interfaces/erc4337/IEntryPoint.sol";
 import {UserOperation} from "../../src/interfaces/erc4337/UserOperation.sol";
+import {FunctionReference} from "../../src/interfaces/IPluginManager.sol";
 import {MultiOwnerPlugin} from "../../src/plugins/owner/MultiOwnerPlugin.sol";
-import {FunctionReference} from "../../src/libraries/FunctionReferenceLib.sol";
 
 import {MultiOwnerMSCAFactory} from "../../src/factory/MultiOwnerMSCAFactory.sol";
 import {

--- a/test/account/phases/AccountStatePhases.t.sol
+++ b/test/account/phases/AccountStatePhases.t.sol
@@ -10,7 +10,7 @@ import {UpgradeableModularAccount} from "../../../src/account/UpgradeableModular
 import {MultiOwnerPlugin} from "../../../src/plugins/owner/MultiOwnerPlugin.sol";
 import {IEntryPoint} from "../../../src/interfaces/erc4337/IEntryPoint.sol";
 import {UserOperation} from "../../../src/interfaces/erc4337/UserOperation.sol";
-import {IPluginManager} from "../../../src/interfaces/IPluginManager.sol";
+import {FunctionReference, IPluginManager} from "../../../src/interfaces/IPluginManager.sol";
 import {IStandardExecutor, Call} from "../../../src/interfaces/IStandardExecutor.sol";
 import {
     IPlugin,
@@ -20,7 +20,7 @@ import {
     ManifestAssociatedFunctionType,
     ManifestAssociatedFunction
 } from "../../../src/interfaces/IPlugin.sol";
-import {FunctionReference, FunctionReferenceLib} from "../../../src/libraries/FunctionReferenceLib.sol";
+import {FunctionReferenceLib} from "../../../src/libraries/FunctionReferenceLib.sol";
 import {MultiOwnerMSCAFactory} from "../../../src/factory/MultiOwnerMSCAFactory.sol";
 
 import {AccountStateMutatingPlugin} from "../../mocks/plugins/AccountStateMutatingPlugin.sol";

--- a/test/libraries/FunctionReferenceLib.t.sol
+++ b/test/libraries/FunctionReferenceLib.t.sol
@@ -2,9 +2,12 @@
 pragma solidity ^0.8.22;
 
 import {Test} from "forge-std/Test.sol";
-import {FunctionReference, FunctionReferenceLib} from "../../src/libraries/FunctionReferenceLib.sol";
+import {FunctionReference} from "../../src/interfaces/IPluginManager.sol";
+import {FunctionReferenceLib} from "../../src/libraries/FunctionReferenceLib.sol";
 
 contract FunctionReferenceLibTest is Test {
+    using FunctionReferenceLib for FunctionReference;
+
     function testFuzz_functionReference_packing(address addr, uint8 functionId) public {
         // console.log("addr: ", addr);
         // console.log("functionId: ", vm.toString(functionId));
@@ -18,19 +21,19 @@ contract FunctionReferenceLibTest is Test {
     }
 
     function testFuzz_functionReference_operators(FunctionReference a, FunctionReference b) public {
-        assertTrue(a == a);
-        assertTrue(b == b);
+        assertTrue(a.eq(a));
+        assertTrue(b.eq(b));
 
         if (FunctionReference.unwrap(a) == FunctionReference.unwrap(b)) {
-            assertTrue(a == b);
-            assertTrue(b == a);
-            assertFalse(a != b);
-            assertFalse(b != a);
+            assertTrue(a.eq(b));
+            assertTrue(b.eq(a));
+            assertFalse(a.notEq(b));
+            assertFalse(b.notEq(a));
         } else {
-            assertTrue(a != b);
-            assertTrue(b != a);
-            assertFalse(a == b);
-            assertFalse(b == a);
+            assertTrue(a.notEq(b));
+            assertTrue(b.notEq(a));
+            assertFalse(a.eq(b));
+            assertFalse(b.eq(a));
         }
     }
 }

--- a/test/mocks/plugins/ExecFromPluginPermissionsMocks.sol
+++ b/test/mocks/plugins/ExecFromPluginPermissionsMocks.sol
@@ -12,8 +12,8 @@ import {
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
 import {IPluginExecutor} from "../../../src/interfaces/IPluginExecutor.sol";
 import {IPlugin} from "../../../src/interfaces/IPlugin.sol";
+import {FunctionReference} from "../../../src/interfaces/IPluginManager.sol";
 import {BaseTestPlugin} from "./BaseTestPlugin.sol";
-import {FunctionReference} from "../../../src/libraries/FunctionReferenceLib.sol";
 
 import {ResultCreatorPlugin} from "./ReturnDataPluginMocks.sol";
 import {Counter} from "../Counter.sol";

--- a/test/mocks/plugins/ManifestValidityMocks.sol
+++ b/test/mocks/plugins/ManifestValidityMocks.sol
@@ -12,8 +12,8 @@ import {
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
 import {IPluginExecutor} from "../../../src/interfaces/IPluginExecutor.sol";
 import {IPlugin} from "../../../src/interfaces/IPlugin.sol";
+import {FunctionReference} from "../../../src/interfaces/IPluginManager.sol";
 import {BaseTestPlugin} from "./BaseTestPlugin.sol";
-import {FunctionReference} from "../../../src/libraries/FunctionReferenceLib.sol";
 
 contract BadValidationMagicValue_UserOp_Plugin is BaseTestPlugin {
     function onInstall(bytes calldata) external override {}

--- a/test/mocks/plugins/ReturnDataPluginMocks.sol
+++ b/test/mocks/plugins/ReturnDataPluginMocks.sol
@@ -11,8 +11,8 @@ import {
 import {IStandardExecutor} from "../../../src/interfaces/IStandardExecutor.sol";
 import {IPluginExecutor} from "../../../src/interfaces/IPluginExecutor.sol";
 import {IPlugin} from "../../../src/interfaces/IPlugin.sol";
+import {FunctionReference} from "../../../src/interfaces/IPluginManager.sol";
 import {BaseTestPlugin} from "./BaseTestPlugin.sol";
-import {FunctionReference} from "../../../src/libraries/FunctionReferenceLib.sol";
 
 contract RegularResultContract {
     function foo() external pure returns (bytes32) {

--- a/test/plugin/TokenReceiverPlugin.t.sol
+++ b/test/plugin/TokenReceiverPlugin.t.sol
@@ -13,9 +13,9 @@ import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Re
 import {TokenReceiverPlugin} from "../../src/plugins/TokenReceiverPlugin.sol";
 import {UpgradeableModularAccount} from "../../src/account/UpgradeableModularAccount.sol";
 import {IEntryPoint} from "../../src/interfaces/erc4337/IEntryPoint.sol";
+import {FunctionReference} from "../../src/interfaces/IPluginManager.sol";
 import {AccountStorageV1} from "../../src/libraries/AccountStorageV1.sol";
 import {MultiOwnerPlugin} from "../../src/plugins/owner/MultiOwnerPlugin.sol";
-import {FunctionReference} from "../../src/libraries/FunctionReferenceLib.sol";
 
 import {MockERC777} from "../mocks/tokens/MockERC777.sol";
 import {MockERC1155} from "../mocks/tokens/MockERC1155.sol";

--- a/test/plugin/owner/MultiOwnerPluginIntegration.t.sol
+++ b/test/plugin/owner/MultiOwnerPluginIntegration.t.sol
@@ -11,11 +11,11 @@ import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {UpgradeableModularAccount} from "../../../src/account/UpgradeableModularAccount.sol";
 import {IEntryPoint} from "../../../src/interfaces/erc4337/IEntryPoint.sol";
 import {UserOperation} from "../../../src/interfaces/erc4337/UserOperation.sol";
+import {FunctionReference} from "../../../src/interfaces/IPluginManager.sol";
 import {MultiOwnerPlugin} from "../../../src/plugins/owner/MultiOwnerPlugin.sol";
 import {IMultiOwnerPlugin} from "../../../src/plugins/owner/IMultiOwnerPlugin.sol";
 import {Utils} from "../../Utils.sol";
 import {Call} from "../../../src/interfaces/IStandardExecutor.sol";
-import {FunctionReference} from "../../../src/libraries/FunctionReferenceLib.sol";
 
 import {Counter} from "../../mocks/Counter.sol";
 import {MultiOwnerMSCAFactory} from "../../../src/factory/MultiOwnerMSCAFactory.sol";

--- a/test/plugin/session/SessionKeyPluginWithMultiOwner.t.sol
+++ b/test/plugin/session/SessionKeyPluginWithMultiOwner.t.sol
@@ -16,7 +16,8 @@ import {ISessionKeyPermissionsUpdates} from
 import {SessionKeyPlugin} from "../../../src/plugins/session/SessionKeyPlugin.sol";
 import {IEntryPoint} from "../../../src/interfaces/erc4337/IEntryPoint.sol";
 import {UserOperation} from "../../../src/interfaces/erc4337/UserOperation.sol";
-import {FunctionReference, FunctionReferenceLib} from "../../../src/libraries/FunctionReferenceLib.sol";
+import {FunctionReference} from "../../../src/interfaces/IPluginManager.sol";
+import {FunctionReferenceLib} from "../../../src/libraries/FunctionReferenceLib.sol";
 import {Call} from "../../../src/interfaces/IStandardExecutor.sol";
 
 import {MultiOwnerMSCAFactory} from "../../../src/factory/MultiOwnerMSCAFactory.sol";

--- a/test/plugin/session/permissions/SessionKeyERC20SpendLimits.t.sol
+++ b/test/plugin/session/permissions/SessionKeyERC20SpendLimits.t.sol
@@ -15,8 +15,9 @@ import {ISessionKeyPermissionsUpdates} from
     "../../../../src/plugins/session/permissions/ISessionKeyPermissionsUpdates.sol";
 import {IEntryPoint} from "../../../../src/interfaces/erc4337/IEntryPoint.sol";
 import {UserOperation} from "../../../../src/interfaces/erc4337/UserOperation.sol";
-import {FunctionReference, FunctionReferenceLib} from "../../../../src/libraries/FunctionReferenceLib.sol";
 import {Call} from "../../../../src/interfaces/IStandardExecutor.sol";
+import {FunctionReference} from "../../../../src/interfaces/IPluginManager.sol";
+import {FunctionReferenceLib} from "../../../../src/libraries/FunctionReferenceLib.sol";
 
 import {MultiOwnerMSCAFactory} from "../../../../src/factory/MultiOwnerMSCAFactory.sol";
 import {MockERC20} from "../../../mocks/tokens/MockERC20.sol";

--- a/test/plugin/session/permissions/SessionKeyGasLimits.t.sol
+++ b/test/plugin/session/permissions/SessionKeyGasLimits.t.sol
@@ -15,8 +15,9 @@ import {ISessionKeyPermissionsUpdates} from
     "../../../../src/plugins/session/permissions/ISessionKeyPermissionsUpdates.sol";
 import {IEntryPoint} from "../../../../src/interfaces/erc4337/IEntryPoint.sol";
 import {UserOperation} from "../../../../src/interfaces/erc4337/UserOperation.sol";
+import {FunctionReference} from "../../../../src/interfaces/IPluginManager.sol";
 import {Call} from "../../../../src/interfaces/IStandardExecutor.sol";
-import {FunctionReference, FunctionReferenceLib} from "../../../../src/libraries/FunctionReferenceLib.sol";
+import {FunctionReferenceLib} from "../../../../src/libraries/FunctionReferenceLib.sol";
 
 import {MultiOwnerMSCAFactory} from "../../../../src/factory/MultiOwnerMSCAFactory.sol";
 

--- a/test/plugin/session/permissions/SessionKeyNativeTokenSpendLimits.t.sol
+++ b/test/plugin/session/permissions/SessionKeyNativeTokenSpendLimits.t.sol
@@ -15,8 +15,9 @@ import {ISessionKeyPermissionsUpdates} from
     "../../../../src/plugins/session/permissions/ISessionKeyPermissionsUpdates.sol";
 import {IEntryPoint} from "../../../../src/interfaces/erc4337/IEntryPoint.sol";
 import {UserOperation} from "../../../../src/interfaces/erc4337/UserOperation.sol";
-import {FunctionReference, FunctionReferenceLib} from "../../../../src/libraries/FunctionReferenceLib.sol";
 import {Call} from "../../../../src/interfaces/IStandardExecutor.sol";
+import {FunctionReference} from "../../../../src/interfaces/IPluginManager.sol";
+import {FunctionReferenceLib} from "../../../../src/libraries/FunctionReferenceLib.sol";
 
 import {MultiOwnerMSCAFactory} from "../../../../src/factory/MultiOwnerMSCAFactory.sol";
 

--- a/test/plugin/session/permissions/SessionKeyPermissions.t.sol
+++ b/test/plugin/session/permissions/SessionKeyPermissions.t.sol
@@ -15,8 +15,9 @@ import {ISessionKeyPermissionsUpdates} from
     "../../../../src/plugins/session/permissions/ISessionKeyPermissionsUpdates.sol";
 import {IEntryPoint} from "../../../../src/interfaces/erc4337/IEntryPoint.sol";
 import {UserOperation} from "../../../../src/interfaces/erc4337/UserOperation.sol";
-import {FunctionReference, FunctionReferenceLib} from "../../../../src/libraries/FunctionReferenceLib.sol";
 import {Call} from "../../../../src/interfaces/IStandardExecutor.sol";
+import {FunctionReference} from "../../../../src/interfaces/IPluginManager.sol";
+import {FunctionReferenceLib} from "../../../../src/libraries/FunctionReferenceLib.sol";
 
 import {Counter} from "../../../mocks/Counter.sol";
 import {MultiOwnerMSCAFactory} from "../../../../src/factory/MultiOwnerMSCAFactory.sol";


### PR DESCRIPTION
This allows a clean separation between CC0 interfaces and types (as defined in ERC-6900) and implementation-specific code.