### PR TITLE
fix: update interface comments and pluginInitData parameter name

### DIFF
--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -289,7 +289,7 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
     function _installPlugin(
         address plugin,
         bytes32 manifestHash,
-        bytes memory pluginInitData,
+        bytes memory pluginInstallData,
         FunctionReference[] memory dependencies
     ) internal {
         AccountStorage storage storage_ = _getAccountStorage();
@@ -469,7 +469,7 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
 
         // Initialize the plugin storage for the account.
         // solhint-disable-next-line no-empty-blocks
-        try IPlugin(plugin).onInstall(pluginInitData) {}
+        try IPlugin(plugin).onInstall(pluginInstallData) {}
         catch (bytes memory revertReason) {
             revert PluginInstallCallbackFailed(plugin, revertReason);
         }

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -330,11 +330,11 @@ contract UpgradeableModularAccount is
     function installPlugin(
         address plugin,
         bytes32 manifestHash,
-        bytes calldata pluginInitData,
+        bytes calldata pluginInstallData,
         FunctionReference[] calldata dependencies
     ) external override {
         (FunctionReference[][] memory postExecHooks, bytes[] memory postHookArgs) = _preNativeFunction();
-        _installPlugin(plugin, manifestHash, pluginInitData, dependencies);
+        _installPlugin(plugin, manifestHash, pluginInstallData, dependencies);
         _postNativeFunction(postExecHooks, postHookArgs);
     }
 

--- a/src/interfaces/IAccountInitializable.sol
+++ b/src/interfaces/IAccountInitializable.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.22;
 
 /// @title Account Initializable Interface
 interface IAccountInitializable {
-    /// @notice Initializes the account with a set of plugins
-    /// @dev No dependencies or hooks can be injected with this installation
-    /// @param plugins The plugins to install
-    /// @param pluginInitData The plugin init data for each plugin
+    /// @notice Initialize the account with a set of plugins.
+    /// @dev No dependencies or hooks can be injected with this installation.
+    /// @param plugins The plugins to install.
+    /// @param pluginInitData The plugin init data for each plugin.
     function initialize(address[] calldata plugins, bytes calldata pluginInitData) external;
 }

--- a/src/interfaces/IAccountLoupe.sol
+++ b/src/interfaces/IAccountLoupe.sol
@@ -5,35 +5,35 @@ import {FunctionReference} from "./IPluginManager.sol";
 
 /// @title Account Loupe Interface
 interface IAccountLoupe {
-    /// @notice Config for an execution function, given a selector
+    /// @notice Config for an execution function, given a selector.
     struct ExecutionFunctionConfig {
         address plugin;
         FunctionReference userOpValidationFunction;
         FunctionReference runtimeValidationFunction;
     }
 
-    /// @notice Pre and post hooks for a given selector
-    /// @dev It's possible for one of either `preExecHook` or `postExecHook` to be empty
+    /// @notice Pre and post hooks for a given selector.
+    /// @dev It's possible for one of either `preExecHook` or `postExecHook` to be empty.
     struct ExecutionHooks {
         FunctionReference preExecHook;
         FunctionReference postExecHook;
     }
 
-    /// @notice Gets the validation functions and plugin address for a selector
-    /// @dev If the selector is a native function, the plugin address will be the address of the account
-    /// @param selector The selector to get the configuration for
-    /// @return The configuration for this selector
+    /// @notice Get the validation functions and plugin address for a selector.
+    /// @dev If the selector is a native function, the plugin address will be the address of the account.
+    /// @param selector The selector to get the configuration for.
+    /// @return The configuration for this selector.
     function getExecutionFunctionConfig(bytes4 selector) external view returns (ExecutionFunctionConfig memory);
 
-    /// @notice Gets the pre and post execution hooks for a selector
-    /// @param selector The selector to get the hooks for
-    /// @return The pre and post execution hooks for this selector
+    /// @notice Get the pre and post execution hooks for a selector.
+    /// @param selector The selector to get the hooks for.
+    /// @return The pre and post execution hooks for this selector.
     function getExecutionHooks(bytes4 selector) external view returns (ExecutionHooks[] memory);
 
-    /// @notice Gets the pre user op and runtime validation hooks associated with a selector
-    /// @param selector The selector to get the hooks for
-    /// @return preUserOpValidationHooks The pre user op validation hooks for this selector
-    /// @return preRuntimeValidationHooks The pre runtime validation hooks for this selector
+    /// @notice Get the pre user op and runtime validation hooks associated with a selector.
+    /// @param selector The selector to get the hooks for.
+    /// @return preUserOpValidationHooks The pre user op validation hooks for this selector.
+    /// @return preRuntimeValidationHooks The pre runtime validation hooks for this selector.
     function getPreValidationHooks(bytes4 selector)
         external
         view
@@ -42,7 +42,7 @@ interface IAccountLoupe {
             FunctionReference[] memory preRuntimeValidationHooks
         );
 
-    /// @notice Gets an array of all installed plugins
-    /// @return The addresses of all installed plugins
+    /// @notice Get an array of all installed plugins.
+    /// @return The addresses of all installed plugins.
     function getInstalledPlugins() external view returns (address[] memory);
 }

--- a/src/interfaces/IAccountView.sol
+++ b/src/interfaces/IAccountView.sol
@@ -5,12 +5,12 @@ import {IEntryPoint} from "./erc4337/IEntryPoint.sol";
 
 /// @title Account View Interface
 interface IAccountView {
-    /// @notice Gets the entry point for this account
-    /// @return entryPoint The entry point for this account
+    /// @notice Get the entry point for this account.
+    /// @return entryPoint The entry point for this account.
     function entryPoint() external view returns (IEntryPoint);
 
     /// @notice Get the account nonce.
-    /// @dev uses key 0
+    /// @dev Uses key 0.
     /// @return nonce The next account nonce.
     function getNonce() external view returns (uint256);
 }

--- a/src/interfaces/IPlugin.sol
+++ b/src/interfaces/IPlugin.sol
@@ -52,28 +52,9 @@ struct ManifestExternalCallPermission {
     bytes4[] selectors;
 }
 
-/// @dev A struct describing how the plugin should be installed on a modular account.
-struct PluginManifest {
-    // List of ERC-165 interfaceIds to add to account to support introspection checks.
-    bytes4[] interfaceIds;
-    // If this plugin depends on other plugins' validation functions, the interface IDs of
-    // those plugins MUST be provided here, with its position in the array matching the `dependencyIndex`
-    // members of `ManifestFunction` structs used in the manifest.
-    bytes4[] dependencyInterfaceIds;
-    // Execution functions defined in this plugin to be installed on the MSCA.
-    bytes4[] executionFunctions;
-    // Plugin execution functions already installed on the MSCA that this plugin will be able to call.
-    bytes4[] permittedExecutionSelectors;
-    // External addresses that this plugin will be able to call.
-    bool permitAnyExternalAddress;
-    // boolean to indicate whether the plugin needs access to spend native tokens of the account
-    bool canSpendNativeToken;
-    ManifestExternalCallPermission[] permittedExternalCalls;
-    ManifestAssociatedFunction[] userOpValidationFunctions;
-    ManifestAssociatedFunction[] runtimeValidationFunctions;
-    ManifestAssociatedFunction[] preUserOpValidationHooks;
-    ManifestAssociatedFunction[] preRuntimeValidationHooks;
-    ManifestExecutionHook[] executionHooks;
+struct SelectorPermission {
+    bytes4 functionSelector;
+    string permissionDescription;
 }
 
 /// @dev A struct holding fields to describe the plugin in a purely view context. Intended for front end clients.
@@ -90,9 +71,30 @@ struct PluginMetadata {
     SelectorPermission[] permissionDescriptors;
 }
 
-struct SelectorPermission {
-    bytes4 functionSelector;
-    string permissionDescription;
+/// @dev A struct describing how the plugin should be installed on a modular account.
+struct PluginManifest {
+    // List of ERC-165 interface IDs to add to account to support introspection checks. This MUST NOT include
+    // IPlugin's interface ID.
+    bytes4[] interfaceIds;
+    // If this plugin depends on other plugins' validation functions, the interface IDs of those plugins MUST be
+    // provided here, with its position in the array matching the `dependencyIndex` members of `ManifestFunction`
+    // structs used in the manifest.
+    bytes4[] dependencyInterfaceIds;
+    // Execution functions defined in this plugin to be installed on the MSCA.
+    bytes4[] executionFunctions;
+    // Plugin execution functions already installed on the MSCA that this plugin will be able to call.
+    bytes4[] permittedExecutionSelectors;
+    // Boolean to indicate whether the plugin can call any external address.
+    bool permitAnyExternalAddress;
+    // Boolean to indicate whether the plugin needs access to spend native tokens of the account. If false, the
+    // plugin MUST still be able to spend up to the balance that it sends to the account in the same call.
+    bool canSpendNativeToken;
+    ManifestExternalCallPermission[] permittedExternalCalls;
+    ManifestAssociatedFunction[] userOpValidationFunctions;
+    ManifestAssociatedFunction[] runtimeValidationFunctions;
+    ManifestAssociatedFunction[] preUserOpValidationHooks;
+    ManifestAssociatedFunction[] preRuntimeValidationHooks;
+    ManifestExecutionHook[] executionHooks;
 }
 
 /// @title Plugin Interface

--- a/src/interfaces/IPluginExecutor.sol
+++ b/src/interfaces/IPluginExecutor.sol
@@ -3,20 +3,20 @@ pragma solidity ^0.8.22;
 
 /// @title Plugin Executor Interface
 interface IPluginExecutor {
-    /// @notice Method from calls made from plugins to other plugin execution functions. Plugins are not allowed to
-    /// call accounts native functions.
-    /// @dev Permissions must be granted to the calling plugin for the call to go through
-    /// @param data The call data for the call.
+    /// @notice Execute a call from a plugin to another plugin, via an execution function installed on the account.
+    /// @dev Plugins are not allowed to call native functions on the account. Permissions must be granted to the
+    /// calling plugin for the call to go through.
+    /// @param data The calldata to send to the plugin.
     /// @return The return data from the call.
     function executeFromPlugin(bytes calldata data) external payable returns (bytes memory);
 
-    /// @notice Method from calls made from plugins to external addresses.
+    /// @notice Execute a call from a plugin to a non-plugin address.
     /// @dev If the target is a plugin, the call SHOULD revert. Permissions must be granted to the calling plugin
-    /// for the call to go through
+    /// for the call to go through.
     /// @param target The address to be called.
-    /// @param value The value to pass.
-    /// @param data The data to pass.
-    /// @return The result of the call
+    /// @param value The value to send with the call.
+    /// @param data The calldata to send to the target.
+    /// @return The return data from the call.
     function executeFromPluginExternal(address target, uint256 value, bytes calldata data)
         external
         payable

--- a/src/interfaces/IPluginManager.sol
+++ b/src/interfaces/IPluginManager.sol
@@ -7,19 +7,19 @@ type FunctionReference is bytes21;
 interface IPluginManager {
     event PluginInstalled(address indexed plugin, bytes32 manifestHash, FunctionReference[] dependencies);
     event PluginUninstalled(address indexed plugin, bool indexed callbacksSucceeded);
-    event PluginIgnoredHookUnapplyCallbackFailure(address indexed plugin, address indexed providingPlugin);
     event PluginIgnoredUninstallCallbackFailure(address indexed plugin);
 
     /// @notice Install a plugin to the modular account.
     /// @param plugin The plugin to install.
     /// @param manifestHash The hash of the plugin manifest.
-    /// @param pluginInitData Optional data to be decoded and used by the plugin to setup initial plugin data for
-    /// the modular account.
-    /// @param dependencies The dependencies of the plugin, as described in the manifest.
+    /// @param pluginInstallData Optional data to be decoded and used by the plugin to setup initial plugin data
+    /// for the modular account.
+    /// @param dependencies The dependencies of the plugin, as described in the manifest. Each FunctionReference
+    /// MUST be composed of an installed plugin's address and a function ID of its validation function.
     function installPlugin(
         address plugin,
         bytes32 manifestHash,
-        bytes calldata pluginInitData,
+        bytes calldata pluginInstallData,
         FunctionReference[] calldata dependencies
     ) external;
 

--- a/src/interfaces/IStandardExecutor.sol
+++ b/src/interfaces/IStandardExecutor.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.22;
 
 struct Call {
-    // The target address for account to call.
+    // The target address for the account to call.
     address target;
     // The value sent with the call.
     uint256 value;
-    // The call data for the call.
+    // The calldata for the call.
     bytes data;
 }
 
@@ -14,15 +14,15 @@ struct Call {
 interface IStandardExecutor {
     /// @notice Standard execute method.
     /// @dev If the target is a plugin, the call SHOULD revert.
-    /// @param target The target address for account to call.
+    /// @param target The target address for the account to call.
     /// @param value The value sent with the call.
-    /// @param data The call data for the call.
+    /// @param data The calldata for the call.
     /// @return The return data from the call.
     function execute(address target, uint256 value, bytes calldata data) external payable returns (bytes memory);
 
     /// @notice Standard executeBatch method.
-    /// @dev If the target is a plugin, the call SHOULD revert. If any of the transactions revert, the entire batch
-    /// reverts
+    /// @dev If the target is a plugin, the call SHOULD revert. If any of the calls revert, the entire batch MUST
+    /// revert.
     /// @param calls The array of calls.
     /// @return An array containing the return data from the calls.
     function executeBatch(Call[] calldata calls) external payable returns (bytes[] memory);

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -431,7 +431,7 @@ contract UpgradeableModularAccountExecHooksTest is Test {
         account1.installPlugin({
             plugin: address(mockPlugin1),
             manifestHash: manifestHash1,
-            pluginInitData: bytes(""),
+            pluginInstallData: bytes(""),
             dependencies: new FunctionReference[](0)
         });
 
@@ -486,7 +486,7 @@ contract UpgradeableModularAccountExecHooksTest is Test {
         account1.installPlugin({
             plugin: address(mockPlugin2),
             manifestHash: manifestHash2,
-            pluginInitData: bytes(""),
+            pluginInstallData: bytes(""),
             dependencies: dependencies
         });
 

--- a/test/account/AccountPreValidationHooks.t.sol
+++ b/test/account/AccountPreValidationHooks.t.sol
@@ -549,7 +549,7 @@ contract UpgradeableModularAccountPreValidationHooksTest is Test {
         account1.installPlugin({
             plugin: address(mockPlugin1),
             manifestHash: manifestHash1,
-            pluginInitData: bytes(""),
+            pluginInstallData: bytes(""),
             dependencies: new FunctionReference[](0)
         });
 
@@ -597,7 +597,7 @@ contract UpgradeableModularAccountPreValidationHooksTest is Test {
         account1.installPlugin({
             plugin: address(mockPlugin2),
             manifestHash: manifestHash2,
-            pluginInitData: bytes(""),
+            pluginInstallData: bytes(""),
             dependencies: dependencies
         });
 
@@ -634,7 +634,7 @@ contract UpgradeableModularAccountPreValidationHooksTest is Test {
         account1.installPlugin({
             plugin: address(mockPlugin1),
             manifestHash: manifestHash1,
-            pluginInitData: bytes(""),
+            pluginInstallData: bytes(""),
             dependencies: dependencies
         });
     }
@@ -659,7 +659,7 @@ contract UpgradeableModularAccountPreValidationHooksTest is Test {
         account1.installPlugin({
             plugin: address(mockPlugin2),
             manifestHash: manifestHash2,
-            pluginInitData: bytes(""),
+            pluginInstallData: bytes(""),
             dependencies: dependencies
         });
     }

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -73,7 +73,7 @@ contract AccountReturnDataTest is Test {
         account.installPlugin({
             plugin: address(resultCreatorPlugin),
             manifestHash: resultCreatorManifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
         // Add the result consumer plugin to the account
@@ -81,7 +81,7 @@ contract AccountReturnDataTest is Test {
         account.installPlugin({
             plugin: address(resultConsumerPlugin),
             manifestHash: resultConsumerManifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }

--- a/test/account/ExecuteFromPluginPermissions.t.sol
+++ b/test/account/ExecuteFromPluginPermissions.t.sol
@@ -89,7 +89,7 @@ contract ExecuteFromPluginPermissionsTest is Test {
         account.installPlugin({
             plugin: address(resultCreatorPlugin),
             manifestHash: resultCreatorManifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
         // Add the EFP caller plugin to the account
@@ -97,7 +97,7 @@ contract ExecuteFromPluginPermissionsTest is Test {
         account.installPlugin({
             plugin: address(efpCallerPlugin),
             manifestHash: efpCallerManifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
 
@@ -107,7 +107,7 @@ contract ExecuteFromPluginPermissionsTest is Test {
         account.installPlugin({
             plugin: address(efpCallerPluginAnyExternal),
             manifestHash: efpCallerAnyExternalManifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
 
@@ -117,7 +117,7 @@ contract ExecuteFromPluginPermissionsTest is Test {
         account.installPlugin({
             plugin: address(efpCallerPluginAnyExternalCanSpendNativeToken),
             manifestHash: efpCallerAnyExternalCanSpendNativeTokenManifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
 
@@ -126,7 +126,7 @@ contract ExecuteFromPluginPermissionsTest is Test {
         account.installPlugin({
             plugin: address(efpExecutionHookPlugin),
             manifestHash: efpExecutionHookPluginManifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }

--- a/test/account/ManifestValidity.t.sol
+++ b/test/account/ManifestValidity.t.sol
@@ -76,7 +76,7 @@ contract ManifestValidityTest is Test {
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }
@@ -93,7 +93,7 @@ contract ManifestValidityTest is Test {
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }
@@ -110,7 +110,7 @@ contract ManifestValidityTest is Test {
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }
@@ -125,7 +125,7 @@ contract ManifestValidityTest is Test {
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }
@@ -140,7 +140,7 @@ contract ManifestValidityTest is Test {
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }
@@ -156,7 +156,7 @@ contract ManifestValidityTest is Test {
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }
@@ -172,7 +172,7 @@ contract ManifestValidityTest is Test {
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }
@@ -187,7 +187,7 @@ contract ManifestValidityTest is Test {
         account.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -489,7 +489,7 @@ contract UpgradeableModularAccountTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
         vm.stopPrank();

--- a/test/account/UpgradeableModularAccountPluginManager.t.sol
+++ b/test/account/UpgradeableModularAccountPluginManager.t.sol
@@ -77,7 +77,6 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
 
     event PluginInstalled(address indexed plugin, bytes32 manifestHash, FunctionReference[] dependencies);
     event PluginUninstalled(address indexed plugin, bool indexed callbacksSucceeded);
-    event PluginIgnoredHookUnapplyCallbackFailure(address indexed plugin, address indexed providingPlugin);
     event PluginIgnoredUninstallCallbackFailure(address indexed plugin);
     event ReceivedCall(bytes msgData, uint256 msgValue);
 
@@ -138,7 +137,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(sessionKeyPlugin),
             manifestHash: manifestHash,
-            pluginInitData: abi.encode(
+            pluginInstallData: abi.encode(
                 sessionKeys, new bytes32[](sessionKeys.length), new bytes[][](sessionKeys.length)
                 ),
             dependencies: dependencies
@@ -150,7 +149,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(tokenReceiverPlugin),
             manifestHash: manifestHash,
-            pluginInitData: abi.encode(uint48(1 days)),
+            pluginInstallData: abi.encode(uint48(1 days)),
             dependencies: new FunctionReference[](0)
         });
 
@@ -176,7 +175,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(mockPluginWithBadPermittedExec),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }
@@ -188,7 +187,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(tokenReceiverPlugin),
             manifestHash: bytes32(0),
-            pluginInitData: abi.encode(uint48(1 days)),
+            pluginInstallData: abi.encode(uint48(1 days)),
             dependencies: new FunctionReference[](0)
         });
     }
@@ -203,7 +202,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(badPlugin),
             manifestHash: bytes32(0),
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }
@@ -215,7 +214,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(tokenReceiverPlugin),
             manifestHash: manifestHash,
-            pluginInitData: abi.encode(uint48(1 days)),
+            pluginInstallData: abi.encode(uint48(1 days)),
             dependencies: new FunctionReference[](0)
         });
 
@@ -227,7 +226,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(tokenReceiverPlugin),
             manifestHash: manifestHash,
-            pluginInitData: abi.encode(uint48(1 days)),
+            pluginInstallData: abi.encode(uint48(1 days)),
             dependencies: new FunctionReference[](0)
         });
     }
@@ -249,7 +248,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(mockPluginBad),
             manifestHash: manifestHashBad,
-            pluginInitData: bytes(""),
+            pluginInstallData: bytes(""),
             dependencies: new FunctionReference[](0)
         });
     }
@@ -271,7 +270,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(mockPluginBad),
             manifestHash: manifestHashBad,
-            pluginInitData: bytes(""),
+            pluginInstallData: bytes(""),
             dependencies: new FunctionReference[](0)
         });
     }
@@ -289,7 +288,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(mockPluginBad),
             manifestHash: manifestHashBad,
-            pluginInitData: bytes(""),
+            pluginInstallData: bytes(""),
             dependencies: new FunctionReference[](0)
         });
     }
@@ -312,7 +311,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(mockPluginBad),
             manifestHash: manifestHashBad,
-            pluginInitData: bytes(""),
+            pluginInstallData: bytes(""),
             dependencies: new FunctionReference[](0)
         });
     }
@@ -334,7 +333,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(newPlugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: dependencies
         });
 
@@ -348,7 +347,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(newPlugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: dependencies
         });
     }
@@ -361,7 +360,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
 
@@ -382,7 +381,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
 
@@ -410,7 +409,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
 
@@ -455,7 +454,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
 
@@ -648,7 +647,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         account2.installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
     }
@@ -664,7 +663,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
 
@@ -679,7 +678,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(plugin),
             manifestHash: manifestHash,
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
         return address(plugin);
@@ -695,14 +694,14 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
         IPluginManager(account2).installPlugin({
             plugin: address(hooksPlugin),
             manifestHash: keccak256(abi.encode(hooksPlugin.pluginManifest())),
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
         MockPlugin plugin = new MockPlugin(manifest);
         IPluginManager(account2).installPlugin({
             plugin: address(plugin),
             manifestHash: keccak256(abi.encode(plugin.pluginManifest())),
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
         return (address(plugin), address(hooksPlugin));

--- a/test/account/ValidationIntersection.t.sol
+++ b/test/account/ValidationIntersection.t.sol
@@ -73,19 +73,19 @@ contract ValidationIntersectionTest is Test {
         account1.installPlugin({
             plugin: address(noHookPlugin),
             manifestHash: keccak256(abi.encode(noHookPlugin.pluginManifest())),
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
         account1.installPlugin({
             plugin: address(oneHookPlugin),
             manifestHash: keccak256(abi.encode(oneHookPlugin.pluginManifest())),
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
         account1.installPlugin({
             plugin: address(twoHookPlugin),
             manifestHash: keccak256(abi.encode(twoHookPlugin.pluginManifest())),
-            pluginInitData: "",
+            pluginInstallData: "",
             dependencies: new FunctionReference[](0)
         });
         vm.stopPrank();

--- a/test/plugin/session/SessionKeyPluginWithMultiOwner.t.sol
+++ b/test/plugin/session/SessionKeyPluginWithMultiOwner.t.sol
@@ -99,7 +99,7 @@ contract SessionKeyPluginWithMultiOwnerTest is Test {
         account1.installPlugin({
             plugin: address(sessionKeyPlugin),
             manifestHash: manifestHash,
-            pluginInitData: abi.encode(new address[](0), new bytes32[](0), new bytes[][](0)),
+            pluginInstallData: abi.encode(new address[](0), new bytes32[](0), new bytes[][](0)),
             dependencies: dependencies
         });
     }
@@ -208,7 +208,7 @@ contract SessionKeyPluginWithMultiOwnerTest is Test {
         account1.installPlugin({
             plugin: address(sessionKeyPlugin),
             manifestHash: manifestHash,
-            pluginInitData: onInstallData,
+            pluginInstallData: onInstallData,
             dependencies: dependencies
         });
 

--- a/test/plugin/session/permissions/SessionKeyERC20SpendLimits.t.sol
+++ b/test/plugin/session/permissions/SessionKeyERC20SpendLimits.t.sol
@@ -101,7 +101,7 @@ contract SessionKeyERC20SpendLimitsTest is Test {
         account1.installPlugin({
             plugin: address(sessionKeyPlugin),
             manifestHash: manifestHash,
-            pluginInitData: abi.encode(new address[](0), new bytes32[](0), new bytes[][](0)),
+            pluginInstallData: abi.encode(new address[](0), new bytes32[](0), new bytes[][](0)),
             dependencies: dependencies
         });
 

--- a/test/plugin/session/permissions/SessionKeyGasLimits.t.sol
+++ b/test/plugin/session/permissions/SessionKeyGasLimits.t.sol
@@ -92,7 +92,7 @@ contract SessionKeyGasLimitsTest is Test {
         account1.installPlugin({
             plugin: address(sessionKeyPlugin),
             manifestHash: manifestHash,
-            pluginInitData: abi.encode(new address[](0), new bytes32[](0), new bytes[][](0)),
+            pluginInstallData: abi.encode(new address[](0), new bytes32[](0), new bytes[][](0)),
             dependencies: dependencies
         });
 

--- a/test/plugin/session/permissions/SessionKeyNativeTokenSpendLimits.t.sol
+++ b/test/plugin/session/permissions/SessionKeyNativeTokenSpendLimits.t.sol
@@ -97,7 +97,7 @@ contract SessionKeyNativeTokenSpendLimitsTest is Test {
         account1.installPlugin({
             plugin: address(sessionKeyPlugin),
             manifestHash: manifestHash,
-            pluginInitData: abi.encode(new address[](0), new bytes32[](0), new bytes[][](0)),
+            pluginInstallData: abi.encode(new address[](0), new bytes32[](0), new bytes[][](0)),
             dependencies: dependencies
         });
 

--- a/test/plugin/session/permissions/SessionKeyPermissions.t.sol
+++ b/test/plugin/session/permissions/SessionKeyPermissions.t.sol
@@ -107,7 +107,7 @@ contract SessionKeyPermissionsTest is Test {
         account1.installPlugin({
             plugin: address(sessionKeyPlugin),
             manifestHash: manifestHash,
-            pluginInitData: abi.encode(new address[](0), new bytes32[](0), new bytes[][](0)),
+            pluginInstallData: abi.encode(new address[](0), new bytes32[](0), new bytes[][](0)),
             dependencies: dependencies
         });
 
@@ -644,7 +644,7 @@ contract SessionKeyPermissionsTest is Test {
         account1.installPlugin({
             plugin: address(sessionKeyPlugin),
             manifestHash: keccak256(abi.encode(sessionKeyPlugin.pluginManifest())),
-            pluginInitData: abi.encode(new address[](0), new bytes32[](0), new bytes[][](0)),
+            pluginInstallData: abi.encode(new address[](0), new bytes32[](0), new bytes[][](0)),
             dependencies: dependencies
         });
         vm.stopPrank();
@@ -685,7 +685,7 @@ contract SessionKeyPermissionsTest is Test {
         account1.installPlugin({
             plugin: address(sessionKeyPlugin),
             manifestHash: manifestHash,
-            pluginInitData: abi.encode(sessionKeys, tags, sessionKeyPermissions),
+            pluginInstallData: abi.encode(sessionKeys, tags, sessionKeyPermissions),
             dependencies: dependencies
         });
     }


### PR DESCRIPTION
Biggest change to note:
`installPlugin`'s `bytes memory pluginInitData` has been updated to `bytes memory pluginInstallData` for consistency. This follows the 0.7.0 update to ERC-6900. The `pluginInitData` name was also used as part of `IAccountInitializable`'s `initialize` method, where it is used in a different way, so this change improves clarity.

Other things:
- Imperative mood for `@notice` comments.
- Fix typos, grammar.