### PR TITLE
fix: remove PluginIgnoredUninstallCallbackFailure event

### DIFF
--- a/src/account/PluginManagerInternals.sol
+++ b/src/account/PluginManagerInternals.sol
@@ -477,7 +477,7 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
         emit PluginInstalled(plugin, manifestHash, dependencies);
     }
 
-    function _uninstallPlugin(UninstallPluginArgs memory args, bytes calldata uninstallData) internal {
+    function _uninstallPlugin(UninstallPluginArgs memory args, bytes calldata pluginUninstallData) internal {
         AccountStorage storage storage_ = _getAccountStorage();
 
         // Check if the plugin exists.
@@ -628,18 +628,17 @@ abstract contract PluginManagerInternals is IPluginManager, AccountStorageV1 {
         }
 
         // Clear the plugin storage for the account.
-        bool callbacksSucceeded = true;
+        bool onUninstallSucceeded = true;
         // solhint-disable-next-line no-empty-blocks
-        try IPlugin(args.plugin).onUninstall{gas: args.callbackGasLimit}(uninstallData) {}
+        try IPlugin(args.plugin).onUninstall{gas: args.callbackGasLimit}(pluginUninstallData) {}
         catch (bytes memory revertReason) {
             if (!args.forceUninstall) {
                 revert PluginUninstallCallbackFailed(args.plugin, revertReason);
             }
-            callbacksSucceeded = false;
-            emit PluginIgnoredUninstallCallbackFailure(args.plugin);
+            onUninstallSucceeded = false;
         }
 
-        emit PluginUninstalled(args.plugin, callbacksSucceeded);
+        emit PluginUninstalled(args.plugin, onUninstallSucceeded);
     }
 
     function _isValidPluginManifest(PluginManifest memory manifest, bytes32 manifestHash)

--- a/src/account/UpgradeableModularAccount.sol
+++ b/src/account/UpgradeableModularAccount.sol
@@ -67,7 +67,7 @@ contract UpgradeableModularAccount is
         // plugin manifest has changed. If empty, uses the default behavior of
         // calling the plugin to get its current manifest.
         bytes serializedManifest;
-        // If true, will complete the uninstall even if `onUninstall` callbacks revert. Available as an escape
+        // If true, will complete the uninstall even if the `onUninstall` callback reverts. Available as an escape
         // hatch if a plugin is blocking uninstall.
         bool forceUninstall;
         // Maximum amount of gas allowed for each uninstall callback function

--- a/src/interfaces/IPluginManager.sol
+++ b/src/interfaces/IPluginManager.sol
@@ -6,8 +6,7 @@ type FunctionReference is bytes21;
 /// @title Plugin Manager Interface
 interface IPluginManager {
     event PluginInstalled(address indexed plugin, bytes32 manifestHash, FunctionReference[] dependencies);
-    event PluginUninstalled(address indexed plugin, bool indexed callbacksSucceeded);
-    event PluginIgnoredUninstallCallbackFailure(address indexed plugin);
+    event PluginUninstalled(address indexed plugin, bool indexed onUninstallSucceeded);
 
     /// @notice Install a plugin to the modular account.
     /// @param plugin The plugin to install.

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -64,7 +64,7 @@ contract UpgradeableModularAccountExecHooksTest is Test {
     PluginManifest public m2;
 
     event PluginInstalled(address indexed plugin, bytes32 manifestHash, FunctionReference[] dependencies);
-    event PluginUninstalled(address indexed plugin, bool indexed callbacksSucceeded);
+    event PluginUninstalled(address indexed plugin, bool indexed onUninstallSucceeded);
 
     function setUp() public {
         entryPoint = IEntryPoint(address(new EntryPoint()));

--- a/test/account/AccountPreValidationHooks.t.sol
+++ b/test/account/AccountPreValidationHooks.t.sol
@@ -65,7 +65,7 @@ contract UpgradeableModularAccountPreValidationHooksTest is Test {
     uint256 public constant VERIFICATION_GAS_LIMIT = 1000000;
 
     event PluginInstalled(address indexed plugin, bytes32 manifestHash, FunctionReference[] dependencies);
-    event PluginUninstalled(address indexed plugin, bool indexed callbacksSucceeded);
+    event PluginUninstalled(address indexed plugin, bool indexed onUninstallSucceeded);
 
     function setUp() public {
         entryPoint = IEntryPoint(address(new EntryPoint()));

--- a/test/account/UpgradeableModularAccountPluginManager.t.sol
+++ b/test/account/UpgradeableModularAccountPluginManager.t.sol
@@ -76,8 +76,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
     uint256 public constant VERIFICATION_GAS_LIMIT = 2000000;
 
     event PluginInstalled(address indexed plugin, bytes32 manifestHash, FunctionReference[] dependencies);
-    event PluginUninstalled(address indexed plugin, bool indexed callbacksSucceeded);
-    event PluginIgnoredUninstallCallbackFailure(address indexed plugin);
+    event PluginUninstalled(address indexed plugin, bool indexed onUninstallSucceeded);
     event ReceivedCall(bytes msgData, uint256 msgValue);
 
     function setUp() public {
@@ -553,8 +552,6 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
                 callbackGasLimit: 3000
             })
         );
-        vm.expectEmit(true, true, true, true);
-        emit PluginIgnoredUninstallCallbackFailure(plugin);
         vm.expectEmit(true, true, true, true);
         emit PluginUninstalled(plugin, false);
         IPluginManager(account2).uninstallPlugin{gas: 100_000}({

--- a/test/account/phases/AccountStatePhases.t.sol
+++ b/test/account/phases/AccountStatePhases.t.sol
@@ -85,7 +85,7 @@ contract AccountStatePhasesTest is Test {
 
     // Event re-declarations for vm.expectEmit
     event PluginInstalled(address indexed plugin, bytes32 manifestHash, FunctionReference[] dependencies);
-    event PluginUninstalled(address indexed plugin, bool indexed callbacksSucceeded);
+    event PluginUninstalled(address indexed plugin, bool indexed onUninstallSucceeded);
     event ReceivedCall(bytes msgData, uint256 msgValue);
 
     // Empty arrays for convenience


### PR DESCRIPTION
- `event PluginIgnoredUninstallCallbackFailure` is unnecessary now that we don't have hook unapply callbacks with the change from #76. This also did not belong in `IPluginManager`. Removed.
- Updated event PluginUninstalled's parameter name from `callbacksSucceeded` to `onUninstallSucceeded` since there is just one callback now.
- These changes align with the latest ERC update https://github.com/erc6900/reference-implementation/pull/32