### PR TITLE
refactor: rename ContractAccessControlType.NONE to ALLOW_ALL_ACCESS

### DIFF
--- a/src/plugins/session/ISessionKeyPlugin.sol
+++ b/src/plugins/session/ISessionKeyPlugin.sol
@@ -27,9 +27,11 @@ interface ISessionKeyPlugin {
 
     // Valid access control types for contract access control lists.
     enum ContractAccessControlType {
-        ALLOWLIST, // Allowlist is default
+        // Allowlist is default
+        ALLOWLIST,
         DENYLIST,
-        NONE
+        // Disables contract access control
+        ALLOW_ALL_ACCESS
     }
 
     // Struct returned by view functions to provide information about a session key's spend limit.

--- a/test/plugin/session/SessionKeyPluginWithMultiOwner.t.sol
+++ b/test/plugin/session/SessionKeyPluginWithMultiOwner.t.sol
@@ -282,7 +282,8 @@ contract SessionKeyPluginWithMultiOwnerTest is Test {
         // Disable the allowlist and native token spend checking
         bytes[] memory permissionUpdates = new bytes[](2);
         permissionUpdates[0] = abi.encodeCall(
-            ISessionKeyPermissionsUpdates.setAccessListType, (ISessionKeyPlugin.ContractAccessControlType.NONE)
+            ISessionKeyPermissionsUpdates.setAccessListType,
+            (ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS)
         );
         permissionUpdates[1] =
             abi.encodeCall(ISessionKeyPermissionsUpdates.setNativeTokenSpendLimit, (type(uint256).max, 0));
@@ -544,7 +545,8 @@ contract SessionKeyPluginWithMultiOwnerTest is Test {
         // To disable the allowlist and native token spend checking
         bytes[] memory permissionUpdates = new bytes[](2);
         permissionUpdates[0] = abi.encodeCall(
-            ISessionKeyPermissionsUpdates.setAccessListType, (ISessionKeyPlugin.ContractAccessControlType.NONE)
+            ISessionKeyPermissionsUpdates.setAccessListType,
+            (ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS)
         );
         permissionUpdates[1] =
             abi.encodeCall(ISessionKeyPermissionsUpdates.setNativeTokenSpendLimit, (type(uint256).max, 0));

--- a/test/plugin/session/permissions/SessionKeyERC20SpendLimits.t.sol
+++ b/test/plugin/session/permissions/SessionKeyERC20SpendLimits.t.sol
@@ -114,7 +114,8 @@ contract SessionKeyERC20SpendLimitsTest is Test {
         // Disable the allowlist
         bytes[] memory updates = new bytes[](1);
         updates[0] = abi.encodeCall(
-            ISessionKeyPermissionsUpdates.setAccessListType, (ISessionKeyPlugin.ContractAccessControlType.NONE)
+            ISessionKeyPermissionsUpdates.setAccessListType,
+            (ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS)
         );
         vm.prank(owner1);
         SessionKeyPlugin(address(account1)).updateKeyPermissions(sessionKey1, updates);
@@ -137,7 +138,7 @@ contract SessionKeyERC20SpendLimitsTest is Test {
         // correctly
         assertTrue(
             sessionKeyPlugin.getAccessControlType(address(account1), sessionKey1)
-                == ISessionKeyPlugin.ContractAccessControlType.NONE
+                == ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS
         );
     }
 

--- a/test/plugin/session/permissions/SessionKeyGasLimits.t.sol
+++ b/test/plugin/session/permissions/SessionKeyGasLimits.t.sol
@@ -104,7 +104,8 @@ contract SessionKeyGasLimitsTest is Test {
 
         bytes[] memory updates = new bytes[](1);
         updates[0] = abi.encodeCall(
-            ISessionKeyPermissionsUpdates.setAccessListType, (ISessionKeyPlugin.ContractAccessControlType.NONE)
+            ISessionKeyPermissionsUpdates.setAccessListType,
+            (ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS)
         );
         vm.prank(owner1);
         SessionKeyPlugin(address(account1)).updateKeyPermissions(sessionKey1, updates);

--- a/test/plugin/session/permissions/SessionKeyNativeTokenSpendLimits.t.sol
+++ b/test/plugin/session/permissions/SessionKeyNativeTokenSpendLimits.t.sol
@@ -110,7 +110,8 @@ contract SessionKeyNativeTokenSpendLimitsTest is Test {
         // Remove the allowlist
         bytes[] memory updates = new bytes[](1);
         updates[0] = abi.encodeCall(
-            ISessionKeyPermissionsUpdates.setAccessListType, (ISessionKeyPlugin.ContractAccessControlType.NONE)
+            ISessionKeyPermissionsUpdates.setAccessListType,
+            (ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS)
         );
         vm.prank(owner1);
         SessionKeyPlugin(address(account1)).updateKeyPermissions(sessionKey1, updates);
@@ -129,7 +130,7 @@ contract SessionKeyNativeTokenSpendLimitsTest is Test {
         // correctly
         assertTrue(
             sessionKeyPlugin.getAccessControlType(address(account1), sessionKey1)
-                == ISessionKeyPlugin.ContractAccessControlType.NONE
+                == ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS
         );
     }
 

--- a/test/plugin/session/permissions/SessionKeyPermissions.t.sol
+++ b/test/plugin/session/permissions/SessionKeyPermissions.t.sol
@@ -148,7 +148,8 @@ contract SessionKeyPermissionsTest is Test {
         // Remove the allowlist
         bytes[] memory updates = new bytes[](1);
         updates[0] = abi.encodeCall(
-            ISessionKeyPermissionsUpdates.setAccessListType, (ISessionKeyPlugin.ContractAccessControlType.NONE)
+            ISessionKeyPermissionsUpdates.setAccessListType,
+            (ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS)
         );
         vm.prank(owner1);
         SessionKeyPlugin(address(account1)).updateKeyPermissions(sessionKey1, updates);
@@ -369,7 +370,8 @@ contract SessionKeyPermissionsTest is Test {
         // Remove the default allowlist
         bytes[] memory updates = new bytes[](1);
         updates[0] = abi.encodeCall(
-            ISessionKeyPermissionsUpdates.setAccessListType, (ISessionKeyPlugin.ContractAccessControlType.NONE)
+            ISessionKeyPermissionsUpdates.setAccessListType,
+            (ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS)
         );
         vm.prank(owner1);
         SessionKeyPlugin(address(account1)).updateKeyPermissions(sessionKey1, updates);
@@ -458,7 +460,8 @@ contract SessionKeyPermissionsTest is Test {
         // Disable the allowlist and disable native token spend checking.
         bytes[] memory updates = new bytes[](2);
         updates[0] = abi.encodeCall(
-            ISessionKeyPermissionsUpdates.setAccessListType, (ISessionKeyPlugin.ContractAccessControlType.NONE)
+            ISessionKeyPermissionsUpdates.setAccessListType,
+            (ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS)
         );
         updates[1] = abi.encodeCall(ISessionKeyPermissionsUpdates.setNativeTokenSpendLimit, (type(uint256).max, 0));
 
@@ -517,7 +520,8 @@ contract SessionKeyPermissionsTest is Test {
         // Disable the allowlist
         bytes[] memory updates = new bytes[](1);
         updates[0] = abi.encodeCall(
-            ISessionKeyPermissionsUpdates.setAccessListType, (ISessionKeyPlugin.ContractAccessControlType.NONE)
+            ISessionKeyPermissionsUpdates.setAccessListType,
+            (ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS)
         );
         vm.prank(owner1);
         SessionKeyPlugin(address(account1)).updateKeyPermissions(sessionKey1, updates);
@@ -598,7 +602,8 @@ contract SessionKeyPermissionsTest is Test {
 
         bytes[] memory updates = new bytes[](1);
         updates[0] = abi.encodeCall(
-            ISessionKeyPermissionsUpdates.setAccessListType, (ISessionKeyPlugin.ContractAccessControlType.NONE)
+            ISessionKeyPermissionsUpdates.setAccessListType,
+            (ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS)
         );
         vm.prank(owner1);
         SessionKeyPlugin(address(account1)).updateKeyPermissions(sessionKey1, updates);
@@ -608,7 +613,7 @@ contract SessionKeyPermissionsTest is Test {
 
         assertEq(
             uint8(accessControlType1),
-            uint8(ISessionKeyPlugin.ContractAccessControlType.NONE),
+            uint8(ISessionKeyPlugin.ContractAccessControlType.ALLOW_ALL_ACCESS),
             "sessionKey1 should now have no allowlist"
         );
         assertEq(


### PR DESCRIPTION
## Motivation

The enum value `NONE` within the enum type `ContractAccessControlType` is used to describe "no access control"/"access control disabled", but semantically may be interpreted as "no addresses are permitted".

## Solution

To clarify the meaning of this enum value, rename it from `NONE` to `ALLOW_ALL_ACCESS`.