### PR TITLE
fix: validation function ids in session key plugin

### DIFF
--- a/src/plugins/session/SessionKeyPlugin.sol
+++ b/src/plugins/session/SessionKeyPlugin.sol
@@ -57,8 +57,8 @@ contract SessionKeyPlugin is ISessionKeyPlugin, SessionKeyPermissions, BasePlugi
     string internal constant _AUTHOR = "Alchemy";
 
     // Constants used in the manifest
-    uint256 internal constant _MANIFEST_DEPENDENCY_INDEX_OWNER_USER_OP_VALIDATION = 0;
-    uint256 internal constant _MANIFEST_DEPENDENCY_INDEX_OWNER_RUNTIME_VALIDATION = 1;
+    uint256 internal constant _MANIFEST_DEPENDENCY_INDEX_OWNER_RUNTIME_VALIDATION = 0;
+    uint256 internal constant _MANIFEST_DEPENDENCY_INDEX_OWNER_USER_OP_VALIDATION = 1;
 
     // Storage fields
     AssociatedLinkedListSet internal _sessionKeys;
@@ -200,9 +200,9 @@ contract SessionKeyPlugin is ISessionKeyPlugin, SessionKeyPermissions, BasePlugi
         PluginManifest memory manifest;
 
         manifest.dependencyInterfaceIds = new bytes4[](2);
-        manifest.dependencyInterfaceIds[_MANIFEST_DEPENDENCY_INDEX_OWNER_USER_OP_VALIDATION] =
-            type(IPlugin).interfaceId;
         manifest.dependencyInterfaceIds[_MANIFEST_DEPENDENCY_INDEX_OWNER_RUNTIME_VALIDATION] =
+            type(IPlugin).interfaceId;
+        manifest.dependencyInterfaceIds[_MANIFEST_DEPENDENCY_INDEX_OWNER_USER_OP_VALIDATION] =
             type(IPlugin).interfaceId;
 
         manifest.executionFunctions = new bytes4[](5);

--- a/test/plugin/session/SessionKeyPluginWithMultiOwner.t.sol
+++ b/test/plugin/session/SessionKeyPluginWithMultiOwner.t.sol
@@ -90,10 +90,10 @@ contract SessionKeyPluginWithMultiOwnerTest is Test {
         bytes32 manifestHash = keccak256(abi.encode(sessionKeyPlugin.pluginManifest()));
         FunctionReference[] memory dependencies = new FunctionReference[](2);
         dependencies[0] = FunctionReferenceLib.pack(
-            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
+            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
         );
         dependencies[1] = FunctionReferenceLib.pack(
-            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
+            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
         );
         vm.prank(owner1);
         account1.installPlugin({
@@ -194,10 +194,10 @@ contract SessionKeyPluginWithMultiOwnerTest is Test {
         bytes32 manifestHash = keccak256(abi.encode(sessionKeyPlugin.pluginManifest()));
         FunctionReference[] memory dependencies = new FunctionReference[](2);
         dependencies[0] = FunctionReferenceLib.pack(
-            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
+            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
         );
         dependencies[1] = FunctionReferenceLib.pack(
-            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
+            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
         );
 
         for (uint256 i = 0; i < addressCount; i++) {

--- a/test/plugin/session/permissions/SessionKeyERC20SpendLimits.t.sol
+++ b/test/plugin/session/permissions/SessionKeyERC20SpendLimits.t.sol
@@ -92,10 +92,10 @@ contract SessionKeyERC20SpendLimitsTest is Test {
         bytes32 manifestHash = keccak256(abi.encode(sessionKeyPlugin.pluginManifest()));
         FunctionReference[] memory dependencies = new FunctionReference[](2);
         dependencies[0] = FunctionReferenceLib.pack(
-            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
+            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
         );
         dependencies[1] = FunctionReferenceLib.pack(
-            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
+            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
         );
         vm.prank(owner1);
         account1.installPlugin({

--- a/test/plugin/session/permissions/SessionKeyGasLimits.t.sol
+++ b/test/plugin/session/permissions/SessionKeyGasLimits.t.sol
@@ -83,10 +83,10 @@ contract SessionKeyGasLimitsTest is Test {
         bytes32 manifestHash = keccak256(abi.encode(sessionKeyPlugin.pluginManifest()));
         FunctionReference[] memory dependencies = new FunctionReference[](2);
         dependencies[0] = FunctionReferenceLib.pack(
-            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
+            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
         );
         dependencies[1] = FunctionReferenceLib.pack(
-            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
+            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
         );
         vm.prank(owner1);
         account1.installPlugin({

--- a/test/plugin/session/permissions/SessionKeyNativeTokenSpendLimits.t.sol
+++ b/test/plugin/session/permissions/SessionKeyNativeTokenSpendLimits.t.sol
@@ -88,10 +88,10 @@ contract SessionKeyNativeTokenSpendLimitsTest is Test {
         bytes32 manifestHash = keccak256(abi.encode(sessionKeyPlugin.pluginManifest()));
         FunctionReference[] memory dependencies = new FunctionReference[](2);
         dependencies[0] = FunctionReferenceLib.pack(
-            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
+            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
         );
         dependencies[1] = FunctionReferenceLib.pack(
-            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
+            address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
         );
         vm.prank(owner1);
         account1.installPlugin({

--- a/test/plugin/session/permissions/SessionKeyPermissions.t.sol
+++ b/test/plugin/session/permissions/SessionKeyPermissions.t.sol
@@ -95,12 +95,12 @@ contract SessionKeyPermissionsTest is Test {
         bytes32 manifestHash = keccak256(abi.encode(sessionKeyPlugin.pluginManifest()));
         dependencies.push(
             FunctionReferenceLib.pack(
-                address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
+                address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
             )
         );
         dependencies.push(
             FunctionReferenceLib.pack(
-                address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.RUNTIME_VALIDATION_OWNER_OR_SELF)
+                address(multiOwnerPlugin), uint8(IMultiOwnerPlugin.FunctionId.USER_OP_VALIDATION_OWNER)
             )
         );
         vm.prank(owner1);


### PR DESCRIPTION
## Motivation

Because `IMultiOwnerPlugin` defines the runtime validation function ID as 0, and the user op validation function ID as 1, it would be less confusing to developers to maintain the expected ordering when providing dependencies to SessionKeyPlugin.

## Solution

Swap the indices for `_MANIFEST_DEPENDENCY_INDEX_OWNER_USER_OP_VALIDATION` and `_MANIFEST_DEPENDENCY_INDEX_OWNER_RUNTIME_VALIDATION`, and the ordering within its manifest's `dependencyInterfaceIds`.