### PR TITLE
feat: add name & version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "modular-account",
+  "version": "v1.0.1",
   "devDependencies": {
     "pnpm": "^8.7.5",
     "solhint": "^3.6.2"

--- a/test/account/UpgradeableModularAccount.t.sol
+++ b/test/account/UpgradeableModularAccount.t.sol
@@ -237,7 +237,7 @@ contract UpgradeableModularAccountTest is Test {
             initCode: "",
             callData: abi.encodeCall(
                 UpgradeableModularAccount.execute, (address(counter), 0, abi.encodeCall(counter.increment, ()))
-                ),
+            ),
             callGasLimit: CALL_GAS_LIMIT,
             verificationGasLimit: VERIFICATION_GAS_LIMIT,
             preVerificationGas: 0,

--- a/test/account/UpgradeableModularAccountPluginManager.t.sol
+++ b/test/account/UpgradeableModularAccountPluginManager.t.sol
@@ -135,7 +135,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
             manifestHash: manifestHash,
             pluginInstallData: abi.encode(
                 sessionKeys, new bytes32[](sessionKeys.length), new bytes[][](sessionKeys.length)
-                ),
+            ),
             dependencies: dependencies
         });
 
@@ -563,7 +563,7 @@ contract UpgradeableModularAccountPluginManagerTest is Test {
             value: 0,
             data: abi.encodeCall(
                 IPluginManager.installPlugin, (address(plugin), manifestHash, "", new FunctionReference[](0))
-                )
+            )
         });
         vm.expectEmit(true, true, true, true);
         emit PluginUninstalled(address(multiOwnerPlugin), true);

--- a/test/account/phases/AccountStatePhases.t.sol
+++ b/test/account/phases/AccountStatePhases.t.sol
@@ -310,7 +310,7 @@ contract AccountStatePhasesTest is Test {
             value: 0 ether,
             data: abi.encodeCall(
                 IPluginManager.installPlugin, (address(mockPlugin1), manifestHash1, "", _EMPTY_DEPENDENCIES)
-                )
+            )
         });
         return calls;
     }

--- a/test/comparison/CompareSimpleAccount.t.sol
+++ b/test/comparison/CompareSimpleAccount.t.sol
@@ -152,7 +152,7 @@ contract CompareSimpleAccountTest is Test {
             initCode: "",
             callData: abi.encodeCall(
                 SimpleAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ()))
-                ),
+            ),
             callGasLimit: 5000000,
             verificationGasLimit: 5000000,
             preVerificationGas: 0,

--- a/test/plugin/session/SessionKeyPluginWithMultiOwner.t.sol
+++ b/test/plugin/session/SessionKeyPluginWithMultiOwner.t.sol
@@ -299,7 +299,7 @@ contract SessionKeyPluginWithMultiOwnerTest is Test {
             initCode: "",
             callData: abi.encodeCall(
                 ISessionKeyPlugin(address(sessionKeyPlugin)).executeWithSessionKey, (calls, sessionKey1)
-                ),
+            ),
             callGasLimit: CALL_GAS_LIMIT,
             verificationGasLimit: VERIFICATION_GAS_LIMIT,
             preVerificationGas: 0,
@@ -350,7 +350,7 @@ contract SessionKeyPluginWithMultiOwnerTest is Test {
             initCode: "",
             callData: abi.encodeCall(
                 ISessionKeyPlugin(address(sessionKeyPlugin)).executeWithSessionKey, (calls, signerAddress)
-                ),
+            ),
             callGasLimit: CALL_GAS_LIMIT,
             verificationGasLimit: VERIFICATION_GAS_LIMIT,
             preVerificationGas: 0,
@@ -391,7 +391,7 @@ contract SessionKeyPluginWithMultiOwnerTest is Test {
             initCode: "",
             callData: abi.encodeCall(
                 ISessionKeyPlugin(address(sessionKeyPlugin)).executeWithSessionKey, (calls, signer)
-                ),
+            ),
             callGasLimit: CALL_GAS_LIMIT,
             verificationGasLimit: VERIFICATION_GAS_LIMIT,
             preVerificationGas: 0,
@@ -430,7 +430,7 @@ contract SessionKeyPluginWithMultiOwnerTest is Test {
             initCode: "",
             callData: abi.encodeCall(
                 ISessionKeyPlugin(address(sessionKeyPlugin)).executeWithSessionKey, (calls, signer)
-                ),
+            ),
             callGasLimit: CALL_GAS_LIMIT,
             verificationGasLimit: VERIFICATION_GAS_LIMIT,
             preVerificationGas: 0,


### PR DESCRIPTION
## Motivation

As noted in #157, the lack of a name and version in `package.json` prevents importing this repo as an NPM package, and only allows using it as a submodule. We want to make it easy for developers to build on ModularAccount, so we should enable this workflow too.

## Solution

Add a name and version to `package.json`.