### PR TITLE
feat: add allowlist module

### DIFF
--- a/src/modules/permissions/AllowlistModule.sol
+++ b/src/modules/permissions/AllowlistModule.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.26;
+
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
+
+import {Call, IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
+import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
+
+import {BaseModule} from "../../modules/BaseModule.sol";
+
+/// @title Allowlist Module
+/// @author Alchemy
+/// @notice This module allows for the setting and enforcement of allowlists for validation functions. These
+/// allowlists can specify which addresses can be called by the validation function, and optionally which selectors
+/// can be called on those addresses. These restrictions only apply to the `IModularAccount.execute` and
+/// `IModularAccount.executeBatch` functions.
+contract AllowlistModule is IValidationHookModule, BaseModule {
+    struct AllowlistInit {
+        address target;
+        bool hasSelectorAllowlist;
+        bytes4[] selectors;
+    }
+
+    struct AllowlistEntry {
+        bool allowed;
+        bool hasSelectorAllowlist;
+    }
+
+    mapping(uint32 entityId => mapping(address target => mapping(address account => AllowlistEntry))) public
+        targetAllowlist;
+    mapping(
+        uint32 entityId => mapping(address target => mapping(bytes4 selector => mapping(address account => bool)))
+    ) public selectorAllowlist;
+
+    event AllowlistTargetUpdated(
+        uint32 indexed entityId, address indexed account, address indexed target, AllowlistEntry entry
+    );
+    event AllowlistSelectorUpdated(
+        uint32 indexed entityId, address indexed account, bytes24 indexed targetAndSelector, bool allowed
+    );
+
+    error TargetNotAllowed();
+    error SelectorNotAllowed();
+    error NoSelectorSpecified();
+
+    /// @inheritdoc IModule
+    /// @dev The `data` parameter is expected to be encoded as `(uint32 entityId, AllowlistInit[] init)`.
+    function onInstall(bytes calldata data) external override {
+        (uint32 entityId, AllowlistInit[] memory init) = abi.decode(data, (uint32, AllowlistInit[]));
+
+        for (uint256 i = 0; i < init.length; i++) {
+            setAllowlistTarget(entityId, init[i].target, true, init[i].hasSelectorAllowlist);
+
+            if (init[i].hasSelectorAllowlist) {
+                for (uint256 j = 0; j < init[i].selectors.length; j++) {
+                    setAllowlistSelector(entityId, init[i].target, init[i].selectors[j], true);
+                }
+            }
+        }
+    }
+
+    /// @inheritdoc IModule
+    /// @dev The `data` parameter is expected to be encoded as `(uint32 entityId, AllowlistInit[] init)`.
+    function onUninstall(bytes calldata data) external override {
+        (uint32 entityId, AllowlistInit[] memory init) = abi.decode(data, (uint32, AllowlistInit[]));
+
+        batchInitAllowlist(entityId, init);
+    }
+
+    /// @inheritdoc IValidationHookModule
+    function preUserOpValidationHook(uint32 entityId, PackedUserOperation calldata userOp, bytes32)
+        external
+        view
+        override
+        returns (uint256)
+    {
+        checkAllowlistCalldata(entityId, userOp.callData);
+        return 0;
+    }
+
+    /// @inheritdoc IValidationHookModule
+    function preRuntimeValidationHook(uint32 entityId, address, uint256, bytes calldata data, bytes calldata)
+        external
+        view
+        override
+    {
+        checkAllowlistCalldata(entityId, data);
+        return;
+    }
+
+    // solhint-disable-next-line no-empty-blocks
+    function preSignatureValidationHook(uint32, address, bytes32, bytes calldata) external pure override {}
+
+    /// @inheritdoc IModule
+    function moduleId() external pure returns (string memory) {
+        return "alchemy.allowlist-module.0.0.1";
+    }
+
+    /// @notice Batch initialize the allowlist for a given entity ID.
+    /// @param entityId The entity ID to initialize the allowlist for.
+    /// @param init The allowlist initialization data.
+    function batchInitAllowlist(uint32 entityId, AllowlistInit[] memory init) public {
+        for (uint256 i = 0; i < init.length; i++) {
+            setAllowlistTarget(entityId, init[i].target, false, false);
+
+            if (init[i].hasSelectorAllowlist) {
+                for (uint256 j = 0; j < init[i].selectors.length; j++) {
+                    setAllowlistSelector(entityId, init[i].target, init[i].selectors[j], false);
+                }
+            }
+        }
+    }
+
+    /// @notice Set the allowlist status for a target address, in the allowlist of the caller account and the
+    /// provided entity ID.
+    /// @param entityId The entity ID to set the allowlist status for.
+    /// @param target The target address.
+    /// @param allowed The new allowlist status, indicating whether or not the target address can be called.
+    /// @param hasSelectorAllowlist Whether or not the target address has a selector allowlist. If true, the
+    /// allowlist checking will validate that the selector is on the selector allowlist.
+    function setAllowlistTarget(uint32 entityId, address target, bool allowed, bool hasSelectorAllowlist) public {
+        AllowlistEntry memory entry = AllowlistEntry(allowed, hasSelectorAllowlist);
+        targetAllowlist[entityId][target][msg.sender] = entry;
+        emit AllowlistTargetUpdated(entityId, msg.sender, target, entry);
+    }
+
+    /// @notice Set the allowlist status for a selector, in the allowlist of the caller account and the provided
+    /// entity ID. Note that if the target address does not have a selector allowlist, this update will not be
+    /// reflected on the usage of the allowlist hook.
+    /// @param entityId The entity ID to set the allowlist status for.
+    /// @param target The target address.
+    /// @param selector The selector to set the allowlist status for.
+    /// @param allowed The new allowlist status, indicating whether or not the selector can be called.
+    function setAllowlistSelector(uint32 entityId, address target, bytes4 selector, bool allowed) public {
+        selectorAllowlist[entityId][target][selector][msg.sender] = allowed;
+        bytes24 targetAndSelector = bytes24(bytes24(bytes20(target)) | (bytes24(selector) >> 160));
+        emit AllowlistSelectorUpdated(entityId, msg.sender, targetAndSelector, allowed);
+    }
+
+    /// @notice Check the allowlist status for a call payload. If the call is not allowed, this function will
+    /// revert.
+    /// @param entityId The entity ID to check the allowlist status for.
+    /// @param callData The call payload to check the allowlist status for. This should be a call to either
+    /// `IModularAccount.execute`, or `IModularAccount.executeBatch`.
+    function checkAllowlistCalldata(uint32 entityId, bytes calldata callData) public view {
+        if (bytes4(callData[:4]) == IModularAccount.execute.selector) {
+            (address target,, bytes memory data) = abi.decode(callData[4:], (address, uint256, bytes));
+            _checkCallPermission(entityId, msg.sender, target, data);
+        } else if (bytes4(callData[:4]) == IModularAccount.executeBatch.selector) {
+            Call[] memory calls = abi.decode(callData[4:], (Call[]));
+
+            for (uint256 i = 0; i < calls.length; i++) {
+                _checkCallPermission(entityId, msg.sender, calls[i].target, calls[i].data);
+            }
+        }
+    }
+
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(BaseModule, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IValidationHookModule).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    function _checkCallPermission(uint32 entityId, address account, address target, bytes memory data)
+        internal
+        view
+    {
+        AllowlistEntry storage entry = targetAllowlist[entityId][target][account];
+        (bool allowed, bool hasSelectorAllowlist) = (entry.allowed, entry.hasSelectorAllowlist);
+
+        if (!allowed) {
+            revert TargetNotAllowed();
+        }
+
+        if (hasSelectorAllowlist) {
+            if (data.length < 4) {
+                revert NoSelectorSpecified();
+            }
+
+            bytes4 selector = bytes4(data);
+
+            if (!selectorAllowlist[entityId][target][selector][account]) {
+                revert SelectorNotAllowed();
+            }
+        }
+    }
+}

--- a/test/modules/AllowlistModule.t.sol
+++ b/test/modules/AllowlistModule.t.sol
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.26;
+
+import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
+
+import {Call} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+
+import {ModularAccount} from "../../src/account/ModularAccount.sol";
+import {HookConfigLib} from "../../src/libraries/HookConfigLib.sol";
+import {ModuleEntity, ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
+import {AllowlistModule} from "../../src/modules/permissions/AllowlistModule.sol";
+
+import {Counter} from "../mocks/Counter.sol";
+import {CustomValidationTestBase} from "../utils/CustomValidationTestBase.sol";
+
+contract AllowlistModuleTest is CustomValidationTestBase {
+    AllowlistModule public allowlistModule;
+
+    AllowlistModule.AllowlistInit[] public allowlistInit;
+
+    Counter[] public counters;
+
+    uint32 public constant HOOK_ENTITY_ID = 0;
+
+    event AllowlistTargetUpdated(
+        uint32 indexed entityId,
+        address indexed account,
+        address indexed target,
+        AllowlistModule.AllowlistEntry entry
+    );
+    event AllowlistSelectorUpdated(
+        uint32 indexed entityId, address indexed account, bytes24 indexed targetAndSelector, bool allowed
+    );
+
+    function setUp() public {
+        _signerValidation =
+            ModuleEntityLib.pack(address(singleSignerValidationModule), TEST_DEFAULT_VALIDATION_ENTITY_ID);
+
+        allowlistModule = new AllowlistModule();
+
+        counters = new Counter[](10);
+
+        for (uint256 i = 0; i < counters.length; i++) {
+            counters[i] = new Counter();
+        }
+
+        // Don't call `_customValidationSetup` here, as we want to test various configurations of install data.
+    }
+
+    function testFuzz_allowlistHook_userOp_single(uint256 seed) public {
+        AllowlistModule.AllowlistInit[] memory inits;
+        (inits, seed) = _generateRandomizedAllowlistInit(seed);
+
+        _copyInitToStorage(inits);
+        _customValidationSetup();
+
+        Call[] memory calls = new Call[](1);
+        (calls[0], seed) = _generateRandomCall(seed);
+        bytes memory expectedError = _getExpectedUserOpError(calls);
+
+        _runExecUserOp(calls[0].target, calls[0].data, expectedError);
+    }
+
+    function testFuzz_allowlistHook_userOp_batch(uint256 seed) public {
+        AllowlistModule.AllowlistInit[] memory inits;
+        (inits, seed) = _generateRandomizedAllowlistInit(seed);
+
+        _copyInitToStorage(inits);
+        _customValidationSetup();
+
+        Call[] memory calls;
+        (calls, seed) = _generateRandomCalls(seed);
+        bytes memory expectedError = _getExpectedUserOpError(calls);
+
+        _runExecBatchUserOp(calls, expectedError);
+    }
+
+    function testFuzz_allowlistHook_runtime_single(uint256 seed) public {
+        AllowlistModule.AllowlistInit[] memory inits;
+        (inits, seed) = _generateRandomizedAllowlistInit(seed);
+
+        _copyInitToStorage(inits);
+        _customValidationSetup();
+
+        Call[] memory calls = new Call[](1);
+        (calls[0], seed) = _generateRandomCall(seed);
+        bytes memory expectedError = _getExpectedRuntimeError(calls);
+
+        if (keccak256(expectedError) == keccak256("emptyrevert")) {
+            _runtimeExecExpFail(calls[0].target, calls[0].data, "");
+        } else {
+            _runtimeExec(calls[0].target, calls[0].data, expectedError);
+        }
+    }
+
+    function testFuzz_allowlistHook_runtime_batch(uint256 seed) public {
+        AllowlistModule.AllowlistInit[] memory inits;
+        (inits, seed) = _generateRandomizedAllowlistInit(seed);
+
+        _copyInitToStorage(inits);
+        _customValidationSetup();
+
+        Call[] memory calls;
+        (calls, seed) = _generateRandomCalls(seed);
+        bytes memory expectedError = _getExpectedRuntimeError(calls);
+
+        if (keccak256(expectedError) == keccak256("emptyrevert")) {
+            _runtimeExecBatchExpFail(calls, "");
+        } else {
+            _runtimeExecBatch(calls, expectedError);
+        }
+    }
+
+    function _beforeInstallStep(address accountImpl) internal override {
+        // Expect events to be emitted from onInstall
+        for (uint256 i = 0; i < allowlistInit.length; i++) {
+            vm.expectEmit(address(allowlistModule));
+            emit AllowlistTargetUpdated(
+                HOOK_ENTITY_ID,
+                accountImpl,
+                allowlistInit[i].target,
+                AllowlistModule.AllowlistEntry({
+                    allowed: true,
+                    hasSelectorAllowlist: allowlistInit[i].hasSelectorAllowlist
+                })
+            );
+
+            if (!allowlistInit[i].hasSelectorAllowlist) {
+                continue;
+            }
+
+            for (uint256 j = 0; j < allowlistInit[i].selectors.length; j++) {
+                bytes24 targetAndSelector = bytes24(
+                    bytes24(bytes20(allowlistInit[i].target)) | (bytes24(allowlistInit[i].selectors[j]) >> 160)
+                );
+                vm.expectEmit(address(allowlistModule));
+                emit AllowlistSelectorUpdated(HOOK_ENTITY_ID, accountImpl, targetAndSelector, true);
+            }
+        }
+    }
+
+    function _generateRandomCalls(uint256 seed) internal view returns (Call[] memory, uint256) {
+        uint256 length = seed % 10;
+        seed = _next(seed);
+
+        Call[] memory calls = new Call[](length);
+
+        for (uint256 i = 0; i < length; i++) {
+            (calls[i], seed) = _generateRandomCall(seed);
+        }
+
+        return (calls, seed);
+    }
+
+    function _generateRandomCall(uint256 seed) internal view returns (Call memory call, uint256 newSeed) {
+        // Half of the time, the target is a random counter, the other half, it's a random address.
+        bool isCounter = seed % 2 == 0;
+        seed = _next(seed);
+
+        call.target = isCounter ? address(counters[seed % counters.length]) : address(uint160(uint256(seed)));
+        seed = _next(seed);
+
+        bool validSelector = seed % 2 == 0;
+        seed = _next(seed);
+
+        if (validSelector) {
+            uint256 selectorIndex = seed % 3;
+            seed = _next(seed);
+
+            if (selectorIndex == 0) {
+                call.data = abi.encodeCall(Counter.setNumber, (seed % 100));
+            } else if (selectorIndex == 1) {
+                call.data = abi.encodeCall(Counter.increment, ());
+            } else {
+                call.data = abi.encodeWithSignature("number()");
+            }
+
+            seed = _next(seed);
+        } else {
+            call.data = abi.encodePacked(bytes4(uint32(uint256(seed))));
+            seed = _next(seed);
+        }
+
+        return (call, seed);
+    }
+
+    function _getExpectedUserOpError(Call[] memory calls) internal view returns (bytes memory) {
+        for (uint256 i = 0; i < calls.length; i++) {
+            Call memory call = calls[i];
+
+            (bool allowed, bool hasSelectorAllowlist) =
+                allowlistModule.targetAllowlist(HOOK_ENTITY_ID, call.target, address(account1));
+            if (allowed) {
+                if (
+                    hasSelectorAllowlist
+                        && !allowlistModule.selectorAllowlist(
+                            HOOK_ENTITY_ID, call.target, bytes4(call.data), address(account1)
+                        )
+                ) {
+                    return abi.encodeWithSelector(
+                        IEntryPoint.FailedOpWithRevert.selector,
+                        0,
+                        "AA23 reverted",
+                        abi.encodeWithSelector(AllowlistModule.SelectorNotAllowed.selector)
+                    );
+                }
+            } else {
+                return abi.encodeWithSelector(
+                    IEntryPoint.FailedOpWithRevert.selector,
+                    0,
+                    "AA23 reverted",
+                    abi.encodeWithSelector(AllowlistModule.TargetNotAllowed.selector)
+                );
+            }
+        }
+
+        return "";
+    }
+
+    function _getExpectedRuntimeError(Call[] memory calls) internal view returns (bytes memory) {
+        for (uint256 i = 0; i < calls.length; i++) {
+            Call memory call = calls[i];
+
+            (bool allowed, bool hasSelectorAllowlist) =
+                allowlistModule.targetAllowlist(HOOK_ENTITY_ID, call.target, address(account1));
+            if (allowed) {
+                if (
+                    hasSelectorAllowlist
+                        && !allowlistModule.selectorAllowlist(
+                            HOOK_ENTITY_ID, call.target, bytes4(call.data), address(account1)
+                        )
+                ) {
+                    return abi.encodeWithSelector(
+                        ModularAccount.PreRuntimeValidationHookFailed.selector,
+                        address(allowlistModule),
+                        HOOK_ENTITY_ID,
+                        abi.encodeWithSelector(AllowlistModule.SelectorNotAllowed.selector)
+                    );
+                }
+            } else {
+                return abi.encodeWithSelector(
+                    ModularAccount.PreRuntimeValidationHookFailed.selector,
+                    address(allowlistModule),
+                    HOOK_ENTITY_ID,
+                    abi.encodeWithSelector(AllowlistModule.TargetNotAllowed.selector)
+                );
+            }
+        }
+
+        // At this point, we have returned any error that would come from the AllowlistModule.
+        // But, because this is in the runtime path, the Counter itself may throw if it is not a valid selector.
+
+        for (uint256 i = 0; i < calls.length; i++) {
+            Call memory call = calls[i];
+            bytes4 selector = bytes4(call.data);
+
+            if (
+                selector != Counter.setNumber.selector && selector != Counter.increment.selector
+                    && selector != bytes4(abi.encodeWithSignature("number()"))
+            ) {
+                //todo: better define a way to handle empty reverts.
+                return "emptyrevert";
+            }
+        }
+
+        return "";
+    }
+
+    function _generateRandomizedAllowlistInit(uint256 seed)
+        internal
+        view
+        returns (AllowlistModule.AllowlistInit[] memory, uint256)
+    {
+        uint256 length = seed % 10;
+        seed = _next(seed);
+
+        AllowlistModule.AllowlistInit[] memory init = new AllowlistModule.AllowlistInit[](length);
+
+        for (uint256 i = 0; i < length; i++) {
+            // Half the time, the target is a random counter, the other half, it's a random address.
+            bool isCounter = seed % 2 == 0;
+            seed = _next(seed);
+
+            address target =
+                isCounter ? address(counters[seed % counters.length]) : address(uint160(uint256(seed)));
+
+            bool hasSelectorAllowlist = seed % 2 == 0;
+            seed = _next(seed);
+
+            uint256 selectorLength = seed % 10;
+            seed = _next(seed);
+
+            bytes4[] memory selectors = new bytes4[](selectorLength);
+
+            for (uint256 j = 0; j < selectorLength; j++) {
+                // half of the time, the selector is a valid selector on counter, the other half it's a random
+                // selector
+
+                bool isCounterSelector = seed % 2 == 0;
+                seed = _next(seed);
+
+                if (isCounterSelector) {
+                    uint256 selectorIndex = seed % 3;
+                    seed = _next(seed);
+
+                    if (selectorIndex == 0) {
+                        selectors[j] = Counter.setNumber.selector;
+                    } else if (selectorIndex == 1) {
+                        selectors[j] = Counter.increment.selector;
+                    } else {
+                        selectors[j] = bytes4(abi.encodeWithSignature("number()"));
+                    }
+                } else {
+                    selectors[j] = bytes4(uint32(uint256(seed)));
+                    seed = _next(seed);
+                }
+
+                selectors[j] = bytes4(uint32(uint256(keccak256(abi.encodePacked(seed, j)))));
+                seed = _next(seed);
+            }
+
+            init[i] = AllowlistModule.AllowlistInit(target, hasSelectorAllowlist, selectors);
+        }
+
+        return (init, seed);
+    }
+
+    function _next(uint256 seed) internal pure returns (uint256) {
+        return uint256(keccak256(abi.encodePacked(seed)));
+    }
+
+    function _initialValidationConfig()
+        internal
+        virtual
+        override
+        returns (ModuleEntity, bool, bool, bool, bytes4[] memory, bytes memory, bytes[] memory)
+    {
+        bytes[] memory hooks = new bytes[](1);
+        hooks[0] = abi.encodePacked(
+            HookConfigLib.packValidationHook(address(allowlistModule), HOOK_ENTITY_ID),
+            abi.encode(HOOK_ENTITY_ID, allowlistInit)
+        );
+        // patched to also work during SMA tests by differentiating the validation
+        _signerValidation = ModuleEntityLib.pack(address(singleSignerValidationModule), type(uint32).max - 1);
+        return
+            (_signerValidation, true, true, true, new bytes4[](0), abi.encode(type(uint32).max - 1, owner1), hooks);
+    }
+
+    // Unfortunately, this is a feature that solidity has only implemented in via-ir, so we need to do it manually
+    // to be able to run the tests in lite mode.
+    function _copyInitToStorage(AllowlistModule.AllowlistInit[] memory init) internal {
+        for (uint256 i = 0; i < init.length; i++) {
+            allowlistInit.push(init[i]);
+        }
+    }
+}

--- a/test/utils/CustomValidationTestBase.sol
+++ b/test/utils/CustomValidationTestBase.sol
@@ -27,6 +27,8 @@ abstract contract CustomValidationTestBase is AccountTestBase {
 
         account1 = ModularAccount(payable(new ERC1967Proxy{salt: 0}(address(accountImplementation), "")));
 
+        _beforeInstallStep(address(account1));
+
         if (vm.envOr("SMA_TEST", false)) {
             vm.prank(address(entryPoint));
             // The initializer doesn't work on the SMA


### PR DESCRIPTION
## Motivation

We want the ability to apply an allowlist to specific validations on an account.

## Solution

Port over the Allowlist module from the RI. This checks addresses and optionally also checks selectors. It does not check any additional portions of calldata.