### PR TITLE
fix: fix how 6900 dependencies are mapped and imported

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "v1.0.1",
   "dependencies": {
     "account-abstraction": "github:eth-infinitism/account-abstraction#v0.7.0",
-    "modular-account-libs": "github:erc6900/modular-account-libs#v0.8.0-rc.0",
-    "reference-implementation": "github:erc6900/reference-implementation#v0.8.0-rc.1",
+    "@erc6900/modular-account-libs": "github:erc6900/modular-account-libs#v0.8.0-rc.0",
+    "@erc6900/reference-implementation": "github:erc6900/reference-implementation#v0.8.0-rc.1",
     "solady": "github:Vectorized/solady#v0.0.237"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@erc6900/modular-account-libs':
+        specifier: github:erc6900/modular-account-libs#v0.8.0-rc.0
+        version: https://codeload.github.com/erc6900/modular-account-libs/tar.gz/d64adb5bd100d6ad64d0a83b5dc13b356423d852
+      '@erc6900/reference-implementation':
+        specifier: github:erc6900/reference-implementation#v0.8.0-rc.1
+        version: https://codeload.github.com/erc6900/reference-implementation/tar.gz/1038b57677ef8fab6e6c752e12b7f2ea97224cf8
       account-abstraction:
         specifier: github:eth-infinitism/account-abstraction#v0.7.0
         version: accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/d99245ddb2d7bde4d2132757c4394818f1d11da0(ethers@5.7.2)(hardhat@2.22.10(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      modular-account-libs:
-        specifier: github:erc6900/modular-account-libs#v0.8.0-rc.0
-        version: '@erc6900/modular-account-libs@https://codeload.github.com/erc6900/modular-account-libs/tar.gz/d64adb5bd100d6ad64d0a83b5dc13b356423d852'
-      reference-implementation:
-        specifier: github:erc6900/reference-implementation#v0.8.0-rc.1
-        version: '@erc6900/reference-implementation@https://codeload.github.com/erc6900/reference-implementation/tar.gz/1038b57677ef8fab6e6c752e12b7f2ea97224cf8'
       solady:
         specifier: github:Vectorized/solady#v0.0.237
         version: https://codeload.github.com/Vectorized/solady/tar.gz/eb227ea1c5eaa56296e7dd713eb165d5d75891dd

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,5 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
-@modular-account-libs/=node_modules/modular-account-libs/src/
+@erc6900/modular-account-libs/=node_modules/modular-account-libs/src/
 @eth-infinitism/account-abstraction/=node_modules/account-abstraction/contracts/
 account-abstraction/=node_modules/account-abstraction/contracts/
 @openzeppelin/=lib/openzeppelin-contracts/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,5 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
-modular-account-libs/=node_modules/modular-account-libs/src/
+@modular-account-libs/=node_modules/modular-account-libs/src/
 @eth-infinitism/account-abstraction/=node_modules/account-abstraction/contracts/
 account-abstraction/=node_modules/account-abstraction/contracts/
 @openzeppelin/=lib/openzeppelin-contracts/

--- a/remappings.txt
+++ b/remappings.txt
@@ -5,6 +5,6 @@ account-abstraction/=node_modules/account-abstraction/contracts/
 @openzeppelin/=lib/openzeppelin-contracts/
 @alchemy/light-account/=lib/light-account/
 solady=node_modules/solady/src/
-@erc-6900/reference-implementation/=node_modules/@erc6900/reference-implementation/src/
+@erc6900/reference-implementation/=node_modules/@erc6900/reference-implementation/src/
 forge-gas-snapshot/=lib/forge-gas-snapshot/src/
 forge-std/=lib/forge-std/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,10 +1,10 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
-@erc6900/modular-account-libs/=node_modules/modular-account-libs/src/
+@erc6900/modular-account-libs/=node_modules/@erc6900/modular-account-libs/src/
 @eth-infinitism/account-abstraction/=node_modules/account-abstraction/contracts/
 account-abstraction/=node_modules/account-abstraction/contracts/
 @openzeppelin/=lib/openzeppelin-contracts/
 @alchemy/light-account/=lib/light-account/
 solady=node_modules/solady/src/
-@erc-6900/reference-implementation/=node_modules/reference-implementation/src/
+@erc-6900/reference-implementation/=node_modules/@erc6900/reference-implementation/src/
 forge-gas-snapshot/=lib/forge-gas-snapshot/src/
 forge-std/=lib/forge-std/

--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.26;
 
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {HookConfig, ModuleEntity} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+import {HookConfig, ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
 // bytes = keccak256("ERC6900.ModularAccount.Storage")
 bytes32 constant _ACCOUNT_STORAGE_SLOT = 0xc531f081ecdb5a90f38c197521797881a6e5c752a7d451780f325a95f8b91f45;

--- a/src/account/ModularAccount.sol
+++ b/src/account/ModularAccount.sol
@@ -11,16 +11,16 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeab
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {IExecutionHookModule} from "@erc-6900/reference-implementation/interfaces/IExecutionHookModule.sol";
-import {ExecutionManifest} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IExecutionHookModule} from "@erc6900/reference-implementation/interfaces/IExecutionHookModule.sol";
+import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 import {
     Call,
     IModularAccount,
     ModuleEntity,
     ValidationConfig
-} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
-import {IValidationHookModule} from "@erc-6900/reference-implementation/interfaces/IValidationHookModule.sol";
-import {IValidationModule} from "@erc-6900/reference-implementation/interfaces/IValidationModule.sol";
+} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
+import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
 
 import {collectReturnData} from "../helpers/CollectReturnData.sol";
 import {DIRECT_CALL_VALIDATION_ENTITYID} from "../helpers/Constants.sol";

--- a/src/account/ModularAccountView.sol
+++ b/src/account/ModularAccountView.sol
@@ -9,12 +9,12 @@ import {
     HookConfig,
     IModularAccount,
     ModuleEntity
-} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {
     ExecutionDataView,
     IModularAccountView,
     ValidationDataView
-} from "@erc-6900/reference-implementation/interfaces/IModularAccountView.sol";
+} from "@erc6900/reference-implementation/interfaces/IModularAccountView.sol";
 
 import {HookConfigLib} from "../helpers/HookConfigLib.sol";
 import {ExecutionData, ValidationData, getAccountStorage, toHookConfig} from "./AccountStorage.sol";

--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -4,20 +4,20 @@ pragma solidity ^0.8.26;
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {IExecutionHookModule} from "@erc-6900/reference-implementation/interfaces/IExecutionHookModule.sol";
+import {IExecutionHookModule} from "@erc6900/reference-implementation/interfaces/IExecutionHookModule.sol";
 import {
     ExecutionManifest,
     ManifestExecutionHook
-} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
+} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 import {
     HookConfig,
     IModularAccount,
     ModuleEntity,
     ValidationConfig
-} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
-import {IModule} from "@erc-6900/reference-implementation/interfaces/IModule.sol";
-import {IValidationHookModule} from "@erc-6900/reference-implementation/interfaces/IValidationHookModule.sol";
-import {IValidationModule} from "@erc-6900/reference-implementation/interfaces/IValidationModule.sol";
+} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
+import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
+import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
 
 import {collectReturnData} from "../helpers/CollectReturnData.sol";
 import {MAX_PRE_VALIDATION_HOOKS} from "../helpers/Constants.sol";

--- a/src/account/SemiModularAccount.sol
+++ b/src/account/SemiModularAccount.sol
@@ -8,7 +8,7 @@ import {
     IModularAccount,
     ModuleEntity,
     ValidationConfig
-} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";

--- a/src/helpers/HookConfigLib.sol
+++ b/src/helpers/HookConfigLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.26;
 
-import {HookConfig, ModuleEntity} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+import {HookConfig, ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
 // Hook types:
 // Exec hook: bools for hasPre, hasPost

--- a/src/helpers/KnownSelectors.sol
+++ b/src/helpers/KnownSelectors.sol
@@ -7,13 +7,13 @@ import {IPaymaster} from "@eth-infinitism/account-abstraction/interfaces/IPaymas
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
-import {IExecutionHookModule} from "@erc-6900/reference-implementation/interfaces/IExecutionHookModule.sol";
-import {IExecutionModule} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
-import {IModularAccount} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
-import {IModularAccountView} from "@erc-6900/reference-implementation/interfaces/IModularAccountView.sol";
-import {IModule} from "@erc-6900/reference-implementation/interfaces/IModule.sol";
-import {IValidationHookModule} from "@erc-6900/reference-implementation/interfaces/IValidationHookModule.sol";
-import {IValidationModule} from "@erc-6900/reference-implementation/interfaces/IValidationModule.sol";
+import {IExecutionHookModule} from "@erc6900/reference-implementation/interfaces/IExecutionHookModule.sol";
+import {IExecutionModule} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IModularAccountView} from "@erc6900/reference-implementation/interfaces/IModularAccountView.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
+import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
+import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
 
 /// @dev Library to help to check if a selector is a know function selector of the modular account or ERC-4337
 /// contract.

--- a/src/helpers/ModuleEntityLib.sol
+++ b/src/helpers/ModuleEntityLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.26;
 
-import {ModuleEntity} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+import {ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
 library ModuleEntityLib {
     // Magic value for hooks that should always revert.

--- a/src/helpers/ValidationConfigLib.sol
+++ b/src/helpers/ValidationConfigLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.26;
 
-import {ModuleEntity, ValidationConfig} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+import {ModuleEntity, ValidationConfig} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
 // Validation config is a packed representation of a validation function and flags for its configuration.
 // Layout:

--- a/src/modules/BaseModule.sol
+++ b/src/modules/BaseModule.sol
@@ -5,7 +5,7 @@ import {IAccountExecute} from "@eth-infinitism/account-abstraction/interfaces/IA
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {ERC165, IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import {IModule} from "@erc-6900/reference-implementation/interfaces/IModule.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
 
 /// @title Base contract for modules
 /// @dev Implements ERC-165 to support IModule's interface, which is a requirement

--- a/src/modules/TokenReceiverModule.sol
+++ b/src/modules/TokenReceiverModule.sol
@@ -7,12 +7,11 @@ import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Recei
 import {
     ExecutionManifest,
     ManifestExecutionFunction
-} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
+} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 import {
-    ExecutionManifest,
-    IExecutionModule
-} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
-import {IModule} from "@erc-6900/reference-implementation/interfaces/IModule.sol";
+    ExecutionManifest, IExecutionModule
+} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
 
 import {BaseModule} from "./BaseModule.sol";
 

--- a/src/modules/validation/ISingleSignerValidationModule.sol
+++ b/src/modules/validation/ISingleSignerValidationModule.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.26;
 
-import {IValidationModule} from "@erc-6900/reference-implementation/interfaces/IValidationModule.sol";
+import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
 
 interface ISingleSignerValidationModule is IValidationModule {
     /// @notice This event is emitted when Signer of the account's validation changes.

--- a/src/modules/validation/SingleSignerValidationModule.sol
+++ b/src/modules/validation/SingleSignerValidationModule.sol
@@ -6,8 +6,8 @@ import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 
-import {IModule} from "@erc-6900/reference-implementation/interfaces/IModule.sol";
-import {IValidationModule} from "@erc-6900/reference-implementation/interfaces/IValidationModule.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
+import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
 
 import {BaseModule} from "../BaseModule.sol";
 import {ReplaySafeWrapper} from "../ReplaySafeWrapper.sol";

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.26;
 
-import {IExecutionHookModule} from "@erc-6900/reference-implementation/interfaces/IExecutionHookModule.sol";
+import {IExecutionHookModule} from "@erc6900/reference-implementation/interfaces/IExecutionHookModule.sol";
 import {
     ExecutionManifest,
     IModule,
     ManifestExecutionFunction,
     ManifestExecutionHook
-} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
+} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 
 import {MockModule} from "../mocks/modules/MockModule.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.26;
 
-import {Call} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
-import {IModularAccount} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+import {Call} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
 import {DIRECT_CALL_VALIDATION_ENTITYID} from "../../src/helpers/Constants.sol";
 import {ValidationConfigLib} from "../../src/helpers/ValidationConfigLib.sol";

--- a/test/account/DirectCallsFromModule.t.sol
+++ b/test/account/DirectCallsFromModule.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.26;
 
-import {Call, IModularAccount} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+import {Call, IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
 import {ModularAccount} from "../../src/account/ModularAccount.sol";
 import {DIRECT_CALL_VALIDATION_ENTITYID} from "../../src/helpers/Constants.sol";

--- a/test/account/ModularAccount.t.sol
+++ b/test/account/ModularAccount.t.sol
@@ -9,9 +9,9 @@ import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import {ExecutionManifest} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
-import {Call} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
-import {ExecutionDataView} from "@erc-6900/reference-implementation/interfaces/IModularAccountView.sol";
+import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {Call} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {ExecutionDataView} from "@erc6900/reference-implementation/interfaces/IModularAccountView.sol";
 
 import {ModularAccount} from "../../src/account/ModularAccount.sol";
 import {ModuleManagerInternals} from "../../src/account/ModuleManagerInternals.sol";

--- a/test/account/ModularAccountView.t.sol
+++ b/test/account/ModularAccountView.t.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.26;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 
-import {HookConfig, IModularAccount} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+import {HookConfig, IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {
     ExecutionDataView,
     ValidationDataView
-} from "@erc-6900/reference-implementation/interfaces/IModularAccountView.sol";
+} from "@erc6900/reference-implementation/interfaces/IModularAccountView.sol";
 
 import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -6,7 +6,7 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import {IModularAccount, ModuleEntity} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IModularAccount, ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
 import {ModularAccount} from "../../src/account/ModularAccount.sol";
 import {ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";

--- a/test/account/ReplaceModule.t.sol
+++ b/test/account/ReplaceModule.t.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.26;
 
-import {IExecutionHookModule} from "@erc-6900/reference-implementation/interfaces/IExecutionHookModule.sol";
+import {IExecutionHookModule} from "@erc6900/reference-implementation/interfaces/IExecutionHookModule.sol";
 import {
     ExecutionManifest,
     ManifestExecutionFunction,
     ManifestExecutionHook
-} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
+} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 import {
     Call, IModularAccount, ModuleEntity
-} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
-import {IValidationHookModule} from "@erc-6900/reference-implementation/interfaces/IValidationHookModule.sol";
+} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
 
 import {ModularAccount} from "../../src/account/ModularAccount.sol";
 import {HookConfigLib} from "../../src/helpers/HookConfigLib.sol";

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -5,7 +5,7 @@ import {IAccountExecute} from "@eth-infinitism/account-abstraction/interfaces/IA
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {Call, IModularAccount} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+import {Call, IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
 import {ModularAccount} from "../../src/account/ModularAccount.sol";
 import {ModuleEntity, ModuleEntityLib} from "../../src/helpers/ModuleEntityLib.sol";

--- a/test/mocks/modules/ComprehensiveModule.sol
+++ b/test/mocks/modules/ComprehensiveModule.sol
@@ -3,16 +3,16 @@ pragma solidity ^0.8.26;
 
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 
-import {IExecutionHookModule} from "@erc-6900/reference-implementation/interfaces/IExecutionHookModule.sol";
+import {IExecutionHookModule} from "@erc6900/reference-implementation/interfaces/IExecutionHookModule.sol";
 import {
     ExecutionManifest,
     IExecutionModule,
     ManifestExecutionFunction,
     ManifestExecutionHook
-} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
-import {IExecutionModule} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
-import {IValidationHookModule} from "@erc-6900/reference-implementation/interfaces/IValidationHookModule.sol";
-import {IValidationModule} from "@erc-6900/reference-implementation/interfaces/IValidationModule.sol";
+} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IExecutionModule} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
+import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 

--- a/test/mocks/modules/DirectCallModule.sol
+++ b/test/mocks/modules/DirectCallModule.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.26;
 
-import {IExecutionHookModule} from "@erc-6900/reference-implementation/interfaces/IExecutionHookModule.sol";
-import {IModularAccount} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IExecutionHookModule} from "@erc6900/reference-implementation/interfaces/IExecutionHookModule.sol";
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";

--- a/test/mocks/modules/MockAccessControlHookModule.sol
+++ b/test/mocks/modules/MockAccessControlHookModule.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.26;
 
-import {IModularAccount} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
-import {IValidationHookModule} from "@erc-6900/reference-implementation/interfaces/IValidationHookModule.sol";
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {IERC165} from "@openzeppelin/contracts/interfaces/IERC165.sol";
 

--- a/test/mocks/modules/MockModule.sol
+++ b/test/mocks/modules/MockModule.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.26;
 
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-import {IExecutionHookModule} from "@erc-6900/reference-implementation/interfaces/IExecutionHookModule.sol";
-import {ExecutionManifest} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
-import {IModule} from "@erc-6900/reference-implementation/interfaces/IModule.sol";
-import {IValidationModule} from "@erc-6900/reference-implementation/interfaces/IValidationModule.sol";
+import {IExecutionHookModule} from "@erc6900/reference-implementation/interfaces/IExecutionHookModule.sol";
+import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
+import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
 
 contract MockModule is ERC165 {
     // It's super inefficient to hold the entire abi-encoded manifest in storage, but this is fine since it's

--- a/test/mocks/modules/PermittedCallMocks.sol
+++ b/test/mocks/modules/PermittedCallMocks.sol
@@ -5,7 +5,7 @@ import {
     ExecutionManifest,
     IExecutionModule,
     ManifestExecutionFunction
-} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
+} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 import {ResultCreatorModule} from "./ReturnDataModuleMocks.sol";

--- a/test/mocks/modules/ReturnDataModuleMocks.sol
+++ b/test/mocks/modules/ReturnDataModuleMocks.sol
@@ -7,9 +7,9 @@ import {
     ExecutionManifest,
     IExecutionModule,
     ManifestExecutionFunction
-} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
-import {IModularAccount} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
-import {IValidationModule} from "@erc-6900/reference-implementation/interfaces/IValidationModule.sol";
+} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
 
 import {DIRECT_CALL_VALIDATION_ENTITYID} from "../../../src/helpers/Constants.sol";
 

--- a/test/mocks/modules/ValidationModuleMocks.sol
+++ b/test/mocks/modules/ValidationModuleMocks.sol
@@ -7,9 +7,9 @@ import {
     ExecutionManifest,
     IExecutionModule,
     ManifestExecutionFunction
-} from "@erc-6900/reference-implementation/interfaces/IExecutionModule.sol";
-import {IValidationHookModule} from "@erc-6900/reference-implementation/interfaces/IValidationHookModule.sol";
-import {IValidationModule} from "@erc-6900/reference-implementation/interfaces/IValidationModule.sol";
+} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
+import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
 
 import {BaseModule} from "../../../src/modules/BaseModule.sol";
 

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -5,7 +5,7 @@ import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.so
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
-import {Call, IModularAccount} from "@erc-6900/reference-implementation/interfaces/IModularAccount.sol";
+import {Call, IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
 import {AccountFactory} from "../../src/account/AccountFactory.sol";
 import {ModularAccount} from "../../src/account/ModularAccount.sol";


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

The `modular-account-libs` were linked unconventionally.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution
Add `@` to remapping for `modular-account-libs`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->