### PR TITLE
fix: pin evm version

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,7 @@
 [profile.default]
 solc = '0.8.26'
 via_ir = false
+evm_version = 'paris'
 src = 'src'
 test = 'test'
 libs = ['lib', 'node_modules']


### PR DESCRIPTION
## Motivation

While the foundry default EVM version is Paris, we should make it explicit and track it in `foundry.toml`.

## Solution

Specify EVM version Paris in `foundry.toml`.