### PR TITLE
test: add hook ordering test

### DIFF
--- a/test/account/HookOrdering.t.sol
+++ b/test/account/HookOrdering.t.sol
@@ -1,0 +1,627 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+
+import {
+    ExecutionManifest,
+    ManifestExecutionHook
+} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+
+import {DIRECT_CALL_VALIDATION_ENTITYID} from "../../src/helpers/Constants.sol";
+import {HookConfigLib} from "../../src/libraries/HookConfigLib.sol";
+import {ModuleEntity, ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
+import {ValidationConfig, ValidationConfigLib} from "../../src/libraries/ValidationConfigLib.sol";
+
+import {HookOrderCheckerModule} from "../mocks/modules/HookOrderCheckerModule.sol";
+import {AccountTestBase} from "../utils/AccountTestBase.sol";
+
+// Asserts that all hooks and account functions are executed in the correct order:
+// All pre-validation hooks (in forward order)
+// The validation function
+// All pre-exec hooks associated w/ validation (in forward order)
+// All pre-exec hooks associated w/ selector (in forward order)
+// The exec function
+// All post-exec hooks associated w/ selector (in reverse order)
+// All post-exec hooks associated w/ validation (in reverse order)
+//
+// To do this, it installs a special module called HookOrderCheckerModule that is a module of every type, and each
+// implementation reports it's order (from it's entityId) to a storage list. At the end of each execution flow, the
+// list is asserted to be of the right length and contain the elements in the correct order.
+//
+// This test does not assert hook ordering after the removal of any hooks, or the addition of hooks after the first
+// install. That case will need an invariant test + harness to handle the addition and removal of hooks.
+contract HookOrderingTest is AccountTestBase {
+    HookOrderCheckerModule public hookOrderChecker;
+
+    ModuleEntity public orderCheckerValidationEntity;
+
+    function setUp() public {
+        hookOrderChecker = new HookOrderCheckerModule();
+    }
+
+    // Test cases:
+    // User op: module exec function
+    // User op: module exec function, without validation-associated exec hooks, no executeUserOp
+    // User op: module exec function, without validation-associated exec hooks, yes executeUserOp
+    // Runtime: module exec function
+    // Runtime: module exec function, without validation-associated exec hooks
+    // Direct call: module exec function
+    // Direct call: module exec function, without validation-associated exec hooks
+    // User op: account native function
+    // User op: account native function, without validation-associated exec hooks, no executeUserOp
+    // User op: account native function, without validation-associated exec hooks, yes executeUserOp
+    // Runtime: account native function
+    // Runtime: account native function, without validation-associated exec hooks
+    // Direct call: account native function
+    // Direct call: account native function, without validation-associated exec hooks
+    // Signature validation
+
+    // Hook and function setup for all cases except signature validation:
+    //  1. pre validation hook 1
+    //  2. pre validation hook 2
+    //  3. pre validation hook 3
+    //  4. validation
+    //  5. pre exec (validation-assoc) hook 1: pre only
+    //  6. pre exec (validation-assoc) hook 2: post only (skipped)
+    //  7. pre exec (validation-assoc) hook 3: pre and post
+    //  8. pre exec (validation-assoc) hook 4: pre and post
+    //  9. pre exec (validation-assoc) hook 5: pre only
+    // 10. pre exec (validation-assoc) hook 6: post only (skipped)
+    // 11. pre exec (selector-assoc) hook 1: pre only
+    // 12. pre exec (selector-assoc) hook 2: post only (skipped)
+    // 13. pre exec (selector-assoc) hook 3: pre and post
+    // 14. pre exec (selector-assoc) hook 4: pre and post
+    // 15. pre exec (selector-assoc) hook 5: pre only
+    // 16. pre exec (selector-assoc) hook 6: post only (skipped)
+    // 17. exec
+    // 16. post exec (selector-assoc) hook 6: post only
+    // 15. post exec (selector-assoc) hook 5: pre only (skipped)
+    // 14. post exec (selector-assoc) hook 4: pre and post
+    // 13. post exec (selector-assoc) hook 3: pre and post
+    // 12. post exec (selector-assoc) hook 2: post only)
+    // 11. post exec (selector-assoc) hook 1: pre only (skipped)
+    // 10. post exec (validation-assoc) hook 6: post only
+    //  9. post exec (validation-assoc) hook 5: pre only (skipped)
+    //  8. post exec (validation-assoc) hook 4: pre and post
+    //  7. post exec (validation-assoc) hook 3: pre and post
+    //  6. post exec (validation-assoc) hook 2: post only
+    //  5. post exec (validation-assoc) hook 1: pre only (skipped)
+
+    function test_hookOrder_userOp_moduleExecFunction_withAssoc() public {
+        _installOrderCheckerModuleWithValidationAssocExec(4);
+
+        PackedUserOperation memory userOp = PackedUserOperation({
+            sender: address(account1),
+            nonce: 0,
+            initCode: hex"",
+            callData: abi.encodePacked(
+                account1.executeUserOp.selector, abi.encodeCall(HookOrderCheckerModule.foo, (17))
+            ),
+            accountGasLimits: _encodeGas(1_000_000, 1_000_000),
+            preVerificationGas: 0,
+            gasFees: _encodeGas(1, 1),
+            paymasterAndData: hex"",
+            signature: _encodeSignature(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_VALIDATION, hex"")
+        });
+
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = userOp;
+
+        entryPoint.handleOps(userOps, beneficiary);
+
+        _checkInvokeOrderWithValidationAssocExec();
+    }
+
+    function test_hookOrder_userOp_moduleExecFunction_noAssoc_regular() public {
+        _installOrderCheckerModuleNoValidationAssocExec(4);
+
+        PackedUserOperation memory userOp = PackedUserOperation({
+            sender: address(account1),
+            nonce: 0,
+            initCode: hex"",
+            callData: abi.encodeCall(HookOrderCheckerModule.foo, (17)),
+            accountGasLimits: _encodeGas(1_000_000, 1_000_000),
+            preVerificationGas: 0,
+            gasFees: _encodeGas(1, 1),
+            paymasterAndData: hex"",
+            signature: _encodeSignature(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_VALIDATION, hex"")
+        });
+
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = userOp;
+
+        entryPoint.handleOps(userOps, beneficiary);
+
+        _checkInvokeOrderNoValidationAssocExec();
+    }
+
+    function test_hookOrder_userOp_moduleExecFunction_noAssoc_execUO() public {
+        _installOrderCheckerModuleNoValidationAssocExec(4);
+
+        PackedUserOperation memory userOp = PackedUserOperation({
+            sender: address(account1),
+            nonce: 0,
+            initCode: hex"",
+            callData: abi.encodePacked(
+                account1.executeUserOp.selector, abi.encodeCall(HookOrderCheckerModule.foo, (17))
+            ),
+            accountGasLimits: _encodeGas(1_000_000, 1_000_000),
+            preVerificationGas: 0,
+            gasFees: _encodeGas(1, 1),
+            paymasterAndData: hex"",
+            signature: _encodeSignature(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_VALIDATION, hex"")
+        });
+
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = userOp;
+
+        entryPoint.handleOps(userOps, beneficiary);
+
+        _checkInvokeOrderNoValidationAssocExec();
+    }
+
+    function test_hookOrder_runtime_moduleExecFunction() public {
+        _installOrderCheckerModuleWithValidationAssocExec(4);
+
+        account1.executeWithAuthorization(
+            abi.encodeCall(HookOrderCheckerModule.foo, (17)),
+            _encodeSignature(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_VALIDATION, "")
+        );
+
+        _checkInvokeOrderWithValidationAssocExec();
+    }
+
+    function test_hookOrder_runtime_moduleExecFunction_noAssoc() public {
+        _installOrderCheckerModuleNoValidationAssocExec(4);
+
+        account1.executeWithAuthorization(
+            abi.encodeCall(HookOrderCheckerModule.foo, (17)),
+            _encodeSignature(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_VALIDATION, "")
+        );
+
+        _checkInvokeOrderNoValidationAssocExec();
+    }
+
+    function test_hookOrder_directCall_moduleExecFunction() public {
+        _installOrderCheckerModuleWithValidationAssocExec(DIRECT_CALL_VALIDATION_ENTITYID);
+
+        vm.prank(address(hookOrderChecker));
+        HookOrderCheckerModule(address(account1)).foo(17);
+
+        _checkInvokeOrderDirectCallWithValidationAssocExec();
+    }
+
+    function test_hookOrder_directCall_moduleExecFunction_noAssoc() public {
+        _installOrderCheckerModuleNoValidationAssocExec(DIRECT_CALL_VALIDATION_ENTITYID);
+
+        vm.prank(address(hookOrderChecker));
+        HookOrderCheckerModule(address(account1)).foo(17);
+
+        _checkInvokeOrderDirectCallNoValidationAssocExec();
+    }
+
+    function test_hookOrder_userOp_accountNativeFunction_withAssoc() public {
+        _installOrderCheckerModuleWithValidationAssocExec(4);
+
+        PackedUserOperation memory userOp = PackedUserOperation({
+            sender: address(account1),
+            nonce: 0,
+            initCode: hex"",
+            callData: abi.encodePacked(
+                account1.executeUserOp.selector,
+                abi.encodeCall(
+                    account1.execute,
+                    (address(hookOrderChecker), 0 wei, abi.encodeCall(HookOrderCheckerModule.foo, (17)))
+                )
+            ),
+            accountGasLimits: _encodeGas(1_000_000, 1_000_000),
+            preVerificationGas: 0,
+            gasFees: _encodeGas(1, 1),
+            paymasterAndData: hex"",
+            signature: _encodeSignature(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_VALIDATION, hex"")
+        });
+
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = userOp;
+
+        entryPoint.handleOps(userOps, beneficiary);
+
+        _checkInvokeOrderWithValidationAssocExec();
+    }
+
+    function test_hookOrder_userOp_accountNativeFunction_noAssoc_regular() public {
+        _installOrderCheckerModuleNoValidationAssocExec(4);
+
+        PackedUserOperation memory userOp = PackedUserOperation({
+            sender: address(account1),
+            nonce: 0,
+            initCode: hex"",
+            callData: abi.encodeCall(
+                account1.execute, (address(hookOrderChecker), 0 wei, abi.encodeCall(HookOrderCheckerModule.foo, (17)))
+            ),
+            accountGasLimits: _encodeGas(1_000_000, 1_000_000),
+            preVerificationGas: 0,
+            gasFees: _encodeGas(1, 1),
+            paymasterAndData: hex"",
+            signature: _encodeSignature(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_VALIDATION, hex"")
+        });
+
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = userOp;
+
+        entryPoint.handleOps(userOps, beneficiary);
+
+        _checkInvokeOrderNoValidationAssocExec();
+    }
+
+    function test_hookOrder_userOp_accountNativeFunction_noAssoc_execUO() public {
+        _installOrderCheckerModuleNoValidationAssocExec(4);
+
+        PackedUserOperation memory userOp = PackedUserOperation({
+            sender: address(account1),
+            nonce: 0,
+            initCode: hex"",
+            callData: abi.encodePacked(
+                account1.executeUserOp.selector,
+                abi.encodeCall(
+                    account1.execute,
+                    (address(hookOrderChecker), 0 wei, abi.encodeCall(HookOrderCheckerModule.foo, (17)))
+                )
+            ),
+            accountGasLimits: _encodeGas(1_000_000, 1_000_000),
+            preVerificationGas: 0,
+            gasFees: _encodeGas(1, 1),
+            paymasterAndData: hex"",
+            signature: _encodeSignature(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_VALIDATION, hex"")
+        });
+
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = userOp;
+
+        entryPoint.handleOps(userOps, beneficiary);
+
+        _checkInvokeOrderNoValidationAssocExec();
+    }
+
+    function test_hookOrder_runtime_accountNativeFunction_regular() public {
+        _installOrderCheckerModuleWithValidationAssocExec(4);
+
+        account1.executeWithAuthorization(
+            abi.encodeCall(
+                account1.execute,
+                (address(hookOrderChecker), 0 wei, abi.encodeCall(HookOrderCheckerModule.foo, (17)))
+            ),
+            _encodeSignature(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_VALIDATION, "")
+        );
+
+        _checkInvokeOrderWithValidationAssocExec();
+    }
+
+    function test_hookOrder_runtime_accountNativeFunction_noAssoc() public {
+        _installOrderCheckerModuleNoValidationAssocExec(4);
+
+        account1.executeWithAuthorization(
+            abi.encodeCall(
+                account1.execute,
+                (address(hookOrderChecker), 0 wei, abi.encodeCall(HookOrderCheckerModule.foo, (17)))
+            ),
+            _encodeSignature(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_VALIDATION, "")
+        );
+
+        _checkInvokeOrderNoValidationAssocExec();
+    }
+
+    function test_hookOrder_directCall_accountNativeFunction() public {
+        _installOrderCheckerModuleWithValidationAssocExec(DIRECT_CALL_VALIDATION_ENTITYID);
+
+        vm.prank(address(hookOrderChecker));
+        HookOrderCheckerModule(address(account1)).foo(17);
+
+        _checkInvokeOrderDirectCallWithValidationAssocExec();
+    }
+
+    function test_hookOrder_directCall_accountNativeFunction_noAssoc() public {
+        _installOrderCheckerModuleNoValidationAssocExec(DIRECT_CALL_VALIDATION_ENTITYID);
+
+        vm.prank(address(hookOrderChecker));
+        HookOrderCheckerModule(address(account1)).foo(17);
+
+        _checkInvokeOrderDirectCallNoValidationAssocExec();
+    }
+
+    function test_hookOrder_signatureValidation() public {
+        _installOrderCheckerModuleWithValidationAssocExec(4);
+
+        // Technically, the hooks aren't supposed to make state changes during the signature validation flow
+        // because it will be invoked with `staticcall`, so we call `isValidSignature` directly with `call`.
+
+        bytes memory callData = abi.encodeCall(
+            account1.isValidSignature, (bytes32(0), _encode1271Signature(orderCheckerValidationEntity, hex""))
+        );
+
+        (bool success,) = address(account1).call(callData);
+
+        require(success, "HookOrderingTest: signature validation failed");
+
+        _checkInvokeOrderSignatureValidation();
+    }
+
+    function _installOrderCheckerModuleWithValidationAssocExec(uint32 validationEntityId) internal {
+        // Must be done in two steps:
+        // - validation and validation-associated functions
+        // - execution function and selector-associated functions
+
+        (ValidationConfig validationConfig, bytes4[] memory selectors, bytes[] memory startingHooks) =
+            _getValidationInstallDataNoExecHooks(validationEntityId);
+
+        bytes[] memory hooks = new bytes[](9);
+
+        // Pre-validation hooks
+        hooks[0] = startingHooks[0];
+        hooks[1] = startingHooks[1];
+        hooks[2] = startingHooks[2];
+
+        // Validation-associated exec hooks
+        hooks[3] = abi.encodePacked(
+            HookConfigLib.packExecHook({
+                _module: address(hookOrderChecker),
+                _entityId: 5,
+                _hasPre: true,
+                _hasPost: false
+            })
+        );
+        hooks[4] = abi.encodePacked(
+            HookConfigLib.packExecHook({
+                _module: address(hookOrderChecker),
+                _entityId: 6,
+                _hasPre: false,
+                _hasPost: true
+            })
+        );
+        hooks[5] = abi.encodePacked(
+            HookConfigLib.packExecHook({
+                _module: address(hookOrderChecker),
+                _entityId: 7,
+                _hasPre: true,
+                _hasPost: true
+            })
+        );
+        hooks[6] = abi.encodePacked(
+            HookConfigLib.packExecHook({
+                _module: address(hookOrderChecker),
+                _entityId: 8,
+                _hasPre: true,
+                _hasPost: true
+            })
+        );
+        hooks[7] = abi.encodePacked(
+            HookConfigLib.packExecHook({
+                _module: address(hookOrderChecker),
+                _entityId: 9,
+                _hasPre: true,
+                _hasPost: false
+            })
+        );
+        hooks[8] = abi.encodePacked(
+            HookConfigLib.packExecHook({
+                _module: address(hookOrderChecker),
+                _entityId: 10,
+                _hasPre: false,
+                _hasPost: true
+            })
+        );
+
+        vm.prank(address(entryPoint));
+        account1.installValidation(validationConfig, selectors, "", hooks);
+
+        _installExecFunctionWithHooks();
+    }
+
+    function _installOrderCheckerModuleNoValidationAssocExec(uint32 validationEntityId) internal {
+        (ValidationConfig validationConfig, bytes4[] memory selectors, bytes[] memory hooks) =
+            _getValidationInstallDataNoExecHooks(validationEntityId);
+
+        vm.prank(address(entryPoint));
+        account1.installValidation(validationConfig, selectors, "", hooks);
+
+        _installExecFunctionWithHooks();
+    }
+
+    function _installExecFunctionWithHooks() internal {
+        // Install the execution function and selector-associated hooks
+
+        // The executionManifest only contains the execution function, we need to insert the selector-associated
+        // hooks
+        ExecutionManifest memory manifest = hookOrderChecker.executionManifest();
+
+        ManifestExecutionHook[] memory execHooks = new ManifestExecutionHook[](12);
+
+        // Apply hooks to the `foo` function
+        execHooks[0] = ManifestExecutionHook({
+            executionSelector: HookOrderCheckerModule.foo.selector,
+            entityId: 11,
+            isPreHook: true,
+            isPostHook: false
+        });
+        execHooks[1] = ManifestExecutionHook({
+            executionSelector: HookOrderCheckerModule.foo.selector,
+            entityId: 12,
+            isPreHook: false,
+            isPostHook: true
+        });
+        execHooks[2] = ManifestExecutionHook({
+            executionSelector: HookOrderCheckerModule.foo.selector,
+            entityId: 13,
+            isPreHook: true,
+            isPostHook: true
+        });
+        execHooks[3] = ManifestExecutionHook({
+            executionSelector: HookOrderCheckerModule.foo.selector,
+            entityId: 14,
+            isPreHook: true,
+            isPostHook: true
+        });
+        execHooks[4] = ManifestExecutionHook({
+            executionSelector: HookOrderCheckerModule.foo.selector,
+            entityId: 15,
+            isPreHook: true,
+            isPostHook: false
+        });
+        execHooks[5] = ManifestExecutionHook({
+            executionSelector: HookOrderCheckerModule.foo.selector,
+            entityId: 16,
+            isPreHook: false,
+            isPostHook: true
+        });
+
+        // Apply hooks to the `execute` function
+        execHooks[6] = ManifestExecutionHook({
+            executionSelector: account1.execute.selector,
+            entityId: 11,
+            isPreHook: true,
+            isPostHook: false
+        });
+        execHooks[7] = ManifestExecutionHook({
+            executionSelector: account1.execute.selector,
+            entityId: 12,
+            isPreHook: false,
+            isPostHook: true
+        });
+        execHooks[8] = ManifestExecutionHook({
+            executionSelector: account1.execute.selector,
+            entityId: 13,
+            isPreHook: true,
+            isPostHook: true
+        });
+        execHooks[9] = ManifestExecutionHook({
+            executionSelector: account1.execute.selector,
+            entityId: 14,
+            isPreHook: true,
+            isPostHook: true
+        });
+        execHooks[10] = ManifestExecutionHook({
+            executionSelector: account1.execute.selector,
+            entityId: 15,
+            isPreHook: true,
+            isPostHook: false
+        });
+        execHooks[11] = ManifestExecutionHook({
+            executionSelector: account1.execute.selector,
+            entityId: 16,
+            isPreHook: false,
+            isPostHook: true
+        });
+
+        manifest.executionHooks = execHooks;
+
+        vm.prank(address(entryPoint));
+        account1.installExecution(address(hookOrderChecker), manifest, "");
+    }
+
+    function _getValidationInstallDataNoExecHooks(uint32 validationEntityId)
+        internal
+        returns (ValidationConfig, bytes4[] memory, bytes[] memory)
+    {
+        ValidationConfig validationConfig = ValidationConfigLib.pack({
+            _module: address(hookOrderChecker),
+            _entityId: validationEntityId,
+            _isGlobal: false,
+            _isSignatureValidation: true,
+            _isUserOpValidation: true
+        });
+
+        orderCheckerValidationEntity = ModuleEntityLib.pack(address(hookOrderChecker), validationEntityId);
+
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = HookOrderCheckerModule.foo.selector;
+        selectors[1] = account1.execute.selector;
+
+        bytes[] memory hooks = new bytes[](3);
+
+        // Pre-validation hooks
+        hooks[0] =
+            abi.encodePacked(HookConfigLib.packValidationHook({_module: address(hookOrderChecker), _entityId: 1}));
+        hooks[1] =
+            abi.encodePacked(HookConfigLib.packValidationHook({_module: address(hookOrderChecker), _entityId: 2}));
+        hooks[2] =
+            abi.encodePacked(HookConfigLib.packValidationHook({_module: address(hookOrderChecker), _entityId: 3}));
+
+        return (validationConfig, selectors, hooks);
+    }
+
+    function _checkInvokeOrderWithValidationAssocExec() internal view {
+        uint32[] memory expectedOrder = new uint32[](21);
+        uint32[21] memory expectedOrderValues =
+            [uint32(1), 2, 3, 4, 5, 7, 8, 9, 11, 13, 14, 15, 17, 16, 14, 13, 12, 10, 8, 7, 6];
+
+        for (uint256 i = 0; i < expectedOrder.length; i++) {
+            expectedOrder[i] = expectedOrderValues[i];
+        }
+
+        uint256[] memory actualOrder = hookOrderChecker.getRecordedFunctionCalls();
+
+        _assertArrsEqual(expectedOrder, actualOrder);
+    }
+
+    function _checkInvokeOrderDirectCallWithValidationAssocExec() internal view {
+        uint32[] memory expectedOrder = new uint32[](20);
+        uint32[20] memory expectedOrderValues =
+            [uint32(1), 2, 3, 5, 7, 8, 9, 11, 13, 14, 15, 17, 16, 14, 13, 12, 10, 8, 7, 6];
+
+        for (uint256 i = 0; i < expectedOrder.length; i++) {
+            expectedOrder[i] = expectedOrderValues[i];
+        }
+
+        uint256[] memory actualOrder = hookOrderChecker.getRecordedFunctionCalls();
+
+        _assertArrsEqual(expectedOrder, actualOrder);
+    }
+
+    function _checkInvokeOrderNoValidationAssocExec() internal view {
+        uint32[] memory expectedOrder = new uint32[](13);
+        uint32[13] memory expectedOrderValues = [uint32(1), 2, 3, 4, 11, 13, 14, 15, 17, 16, 14, 13, 12];
+
+        for (uint256 i = 0; i < expectedOrder.length; i++) {
+            expectedOrder[i] = expectedOrderValues[i];
+        }
+
+        uint256[] memory actualOrder = hookOrderChecker.getRecordedFunctionCalls();
+
+        _assertArrsEqual(expectedOrder, actualOrder);
+    }
+
+    function _checkInvokeOrderDirectCallNoValidationAssocExec() internal view {
+        uint32[] memory expectedOrder = new uint32[](12);
+        uint32[12] memory expectedOrderValues = [uint32(1), 2, 3, 11, 13, 14, 15, 17, 16, 14, 13, 12];
+
+        for (uint256 i = 0; i < expectedOrder.length; i++) {
+            expectedOrder[i] = expectedOrderValues[i];
+        }
+
+        uint256[] memory actualOrder = hookOrderChecker.getRecordedFunctionCalls();
+
+        _assertArrsEqual(expectedOrder, actualOrder);
+    }
+
+    function _checkInvokeOrderSignatureValidation() internal view {
+        uint32[] memory expectedOrder = new uint32[](4);
+        uint32[4] memory expectedOrderValues = [uint32(1), 2, 3, 4];
+
+        for (uint256 i = 0; i < expectedOrder.length; i++) {
+            expectedOrder[i] = expectedOrderValues[i];
+        }
+
+        uint256[] memory actualOrder = hookOrderChecker.getRecordedFunctionCalls();
+
+        _assertArrsEqual(expectedOrder, actualOrder);
+    }
+
+    function _assertArrsEqual(uint32[] memory expected, uint256[] memory actual) internal pure {
+        assertEq(expected.length, actual.length);
+
+        for (uint256 i = 0; i < expected.length; i++) {
+            assertEq(expected[i], actual[i]);
+        }
+    }
+}

--- a/test/mocks/modules/HookOrderCheckerModule.sol
+++ b/test/mocks/modules/HookOrderCheckerModule.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+
+import {Vm} from "forge-std/src/Vm.sol";
+
+import {IExecutionHookModule} from "@erc6900/reference-implementation/interfaces/IExecutionHookModule.sol";
+import {
+    ExecutionManifest,
+    IExecutionModule,
+    ManifestExecutionFunction,
+    ManifestExecutionHook
+} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
+import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
+
+import {BaseModule} from "../../../src/modules/BaseModule.sol";
+
+// Used within HookOrdering.t.sol, see that file for details on usage.
+contract HookOrderCheckerModule is
+    IValidationModule,
+    IValidationHookModule,
+    IExecutionModule,
+    IExecutionHookModule,
+    BaseModule
+{
+    // Stored as a uint256 to make it easier to do the VM staticcall storage writes
+    uint256[] public recordedFunctionCalls;
+
+    function validateUserOp(uint32 entityId, PackedUserOperation calldata, bytes32) external returns (uint256) {
+        recordedFunctionCalls.push(uint256(entityId));
+
+        return 0;
+    }
+
+    function validateRuntime(address, uint32 entityId, address, uint256, bytes calldata, bytes calldata)
+        external
+    {
+        recordedFunctionCalls.push(uint256(entityId));
+    }
+
+    function validateSignature(address, uint32 entityId, address, bytes32, bytes calldata)
+        external
+        view
+        returns (bytes4)
+    {
+        // Use the VM cheat code to write to storage even in a view context
+        _pushToRecordedFunctionCalls(entityId);
+        return IERC1271.isValidSignature.selector;
+    }
+
+    function preUserOpValidationHook(uint32 entityId, PackedUserOperation calldata, bytes32)
+        external
+        returns (uint256)
+    {
+        recordedFunctionCalls.push(uint256(entityId));
+
+        return 0;
+    }
+
+    function preRuntimeValidationHook(uint32 entityId, address, uint256, bytes calldata, bytes calldata)
+        external
+    {
+        recordedFunctionCalls.push(uint256(entityId));
+    }
+
+    function preSignatureValidationHook(uint32 entityId, address, bytes32, bytes calldata) external view {
+        // Use the VM cheat code to write to storage even in a view context
+        _pushToRecordedFunctionCalls(entityId);
+    }
+
+    function preExecutionHook(uint32 entityId, address, uint256, bytes calldata) external returns (bytes memory) {
+        recordedFunctionCalls.push(uint256(entityId));
+        return "";
+    }
+
+    function postExecutionHook(uint32 entityId, bytes calldata) external {
+        recordedFunctionCalls.push(uint256(entityId));
+    }
+
+    function onInstall(bytes calldata) external override {}
+
+    function onUninstall(bytes calldata) external override {}
+
+    function foo(uint32 index) external {
+        recordedFunctionCalls.push(index);
+    }
+
+    function getRecordedFunctionCalls() external view returns (uint256[] memory) {
+        return recordedFunctionCalls;
+    }
+
+    function moduleId() external pure returns (string memory) {
+        return "alchemy-test.hook-order-checker.v0.0.1";
+    }
+
+    // Does not return any execution hooks, the caller should add any requested execution hooks prior to calling
+    // `installExecution` with the desired entity IDs.
+    function executionManifest() external pure returns (ExecutionManifest memory) {
+        ManifestExecutionFunction[] memory executionFunctions = new ManifestExecutionFunction[](1);
+        executionFunctions[0] = ManifestExecutionFunction({
+            executionSelector: this.foo.selector,
+            skipRuntimeValidation: false,
+            allowGlobalValidation: false
+        });
+
+        return ExecutionManifest({
+            executionFunctions: executionFunctions,
+            executionHooks: new ManifestExecutionHook[](0),
+            interfaceIds: new bytes4[](0)
+        });
+    }
+
+    // Normally we can't write to storage within a staticcall, so the signature validation and signature validation
+    // hooks would be unable to record their access order. However, we can use the VM cheat code to write to
+    // storage even in a view context, so we can record the order of function calls.
+    function _pushToRecordedFunctionCalls(uint32 entityId) internal view {
+        uint256 arrayLength;
+        uint256 arrayLengthSlot;
+        uint256 contentsStartingSlot;
+
+        assembly ("memory-safe") {
+            arrayLengthSlot := recordedFunctionCalls.slot
+            arrayLength := sload(arrayLengthSlot)
+            mstore(0, arrayLengthSlot)
+            contentsStartingSlot := keccak256(0, 32)
+        }
+
+        _store(bytes32(arrayLengthSlot), bytes32(arrayLength + 1));
+
+        _store(bytes32(contentsStartingSlot + arrayLength), bytes32(uint256(entityId)));
+    }
+
+    function _store(bytes32 slot, bytes32 value) internal view {
+        address vm = address(uint160(uint256(keccak256("hevm cheat code"))));
+
+        (bool success,) = vm.staticcall(abi.encodeCall(Vm.store, (address(this), slot, value)));
+
+        if (!success) {
+            revert("VM Staticcall failed");
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

As we start working on changes the account storage, we want to make sure hooks are executed in the correct order. Currently, we don't have a test that asserts this order.

## Solution

Add a test that asserts hook ordering is correct for the common call flows:
- user op / runtime / signature validation
- module exec function / account native function
- with or without `executeUserOp`, and validation-associated exec hooks

The expected order is:
- All pre-validation hooks (in forward order)
- The validation function
- All pre-exec hooks associated w/ validation (in forward order)
- All pre-exec hooks associated w/ selector (in forward order)
- The exec function
- All post-exec hooks associated w/ selector (in reverse order)
- All post-exec hooks associated w/ validation (in reverse order)

To implement this, add a module that logs to storage whenever any module function is invoked, then read the log at the end of the test to assert that the ordering is correct. Then, write a test contract that has all of the permutations of the above cases, and assert the call order after each.

Note that this test only checks the ordering after the first install - it doesn't check behavior for adding hooks, nor for removing individual hooks, which we tentatively plan to support.

### Order checking for signature validation

The external view function `isValidSignature`, and the module functions `validateSignature` and `preSignatureValidationHook`, are all declared `view`. This means the account will invoke the module functions with `staticcall`, and this will make it impossible for the module to write to storage normally. While there are ways to "secretly" store values in the warming of slots, I instead opted to have the module use the `Vm.store` cheatcode, invoked in a non-standard way with a `staticcall`, to append to its own array.