### PR TITLE
fix: fix compiler warning

### DIFF
--- a/test/modules/PaymasterGuardModule.t.sol
+++ b/test/modules/PaymasterGuardModule.t.sol
@@ -73,7 +73,7 @@ contract PaymasterGuardModuleTest is AccountTestBase {
         module.preRuntimeValidationHook(ENTITY_ID, address(0), 0, "", "");
     }
 
-    function _packUO(bytes memory paymasterAndData) internal returns (PackedUserOperation memory) {
+    function _packUO(bytes memory paymasterAndData) internal view returns (PackedUserOperation memory) {
         return PackedUserOperation({
             sender: account,
             nonce: 0,


### PR DESCRIPTION
## Motivation

We currently have a compiler warning:
```
Compiler run successful with warnings:
Warning (2018): Function state mutability can be restricted to view
  --> test/modules/PaymasterGuardModule.t.sol:76:5:
   |
76 |     function _packUO(bytes memory paymasterAndData) internal returns (PackedUserOperation memory) {
   |     ^ (Relevant source part starts here and spans across multiple lines).

```

## Solution

Mark the `_packUO` function as `view`.