### PR TITLE
fix: fix SMA test and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Run tests
         run: FOUNDRY_PROFILE=optimized-test-deep forge test -vvv
 
+      - name: Run SMA tests
+        run: FOUNDRY_PROFILE=optimized-test-deep SMA_TEST=true forge test -vvv
+
   test-default:
     name: Run Forge Tests (default)
     runs-on: ubuntu-latest
@@ -39,3 +42,6 @@ jobs:
 
       - name: Run tests
         run: forge test -vvv
+
+      - name: Run tests
+        run: SMA_TEST=true forge test -vvv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Run tests
         run: forge test -vvv
 
-      - name: Run tests
+      - name: Run SMA tests
         run: SMA_TEST=true forge test -vvv

--- a/test/account/ModularAccount.t.sol
+++ b/test/account/ModularAccount.t.sol
@@ -515,30 +515,28 @@ contract ModularAccountTest is AccountTestBase {
     }
 
     function test_performCreate() public {
-        address account = address(factory.createAccount(owner1, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID));
-        address expectedAddr = vm.computeCreateAddress(account, vm.getNonce(account));
+        address expectedAddr = vm.computeCreateAddress(address(account1), vm.getNonce(address(account1)));
         vm.prank(address(entryPoint));
         address returnedAddr = account1.performCreate(
             0, abi.encodePacked(type(ModularAccount).creationCode, abi.encode(address(entryPoint)))
         );
 
-        assertEq(address(ModularAccount(payable(expectedAddr)).entryPoint()), address(entryPoint));
         assertEq(returnedAddr, expectedAddr);
+        assertEq(address(ModularAccount(payable(expectedAddr)).entryPoint()), address(entryPoint));
     }
 
     function test_performCreate2() public {
-        address account = address(factory.createAccount(owner1, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID));
         bytes memory initCode =
             abi.encodePacked(type(ModularAccount).creationCode, abi.encode(address(entryPoint)));
         bytes32 initCodeHash = keccak256(initCode);
         bytes32 salt = bytes32(hex"01234b");
 
-        address expectedAddr = vm.computeCreate2Address(salt, initCodeHash, address(account));
+        address expectedAddr = vm.computeCreate2Address(salt, initCodeHash, address(account1));
         vm.prank(address(entryPoint));
         address returnedAddr = account1.performCreate2(0, initCode, salt);
 
-        assertEq(address(ModularAccount(payable(expectedAddr)).entryPoint()), address(entryPoint));
         assertEq(returnedAddr, expectedAddr);
+        assertEq(address(ModularAccount(payable(expectedAddr)).entryPoint()), address(entryPoint));
 
         vm.expectRevert(ModularAccountBase.CreateFailed.selector);
         // re-deploying with same salt should revert


### PR DESCRIPTION
## Motivation

The script `pnpm prep` is no longer working, due to an SMA test failure. This accidentally made its way to `develop` because it was missing from CI.

## Solution

Fix the counterfactual address generation in the tests for `performCreate`/`performCreate2`.

Add SMA tests to the CI.