### PR TITLE
test: port library tests and add type safety

### DIFF
--- a/src/libraries/ValidationConfigLib.sol
+++ b/src/libraries/ValidationConfigLib.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.26;
 
 import {ModuleEntity, ValidationConfig} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
+type ValidationFlags is uint8;
+
 // Validation config is a packed representation of a validation function and flags for its configuration.
 // Layout:
 // 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA________________________ // Address
@@ -63,22 +65,22 @@ library ValidationConfigLib {
     function unpackUnderlying(ValidationConfig config)
         internal
         pure
-        returns (address _module, uint32 _entityId, uint8 flags)
+        returns (address _module, uint32 _entityId, ValidationFlags flags)
     {
         bytes25 configBytes = ValidationConfig.unwrap(config);
         _module = address(bytes20(configBytes));
         _entityId = uint32(bytes4(configBytes << 160));
-        flags = uint8(configBytes[24]);
+        flags = ValidationFlags.wrap(uint8(configBytes[24]));
     }
 
     function unpack(ValidationConfig config)
         internal
         pure
-        returns (ModuleEntity _validationFunction, uint8 flags)
+        returns (ModuleEntity _validationFunction, ValidationFlags flags)
     {
         bytes25 configBytes = ValidationConfig.unwrap(config);
         _validationFunction = ModuleEntity.wrap(bytes24(configBytes));
-        flags = uint8(configBytes[24]);
+        flags = ValidationFlags.wrap(uint8(configBytes[24]));
     }
 
     function module(ValidationConfig config) internal pure returns (address) {
@@ -97,23 +99,23 @@ library ValidationConfigLib {
         return ValidationConfig.unwrap(config) & _VALIDATION_FLAG_IS_GLOBAL != 0;
     }
 
-    function isGlobal(uint8 flags) internal pure returns (bool) {
-        return flags & 0x04 != 0;
+    function isGlobal(ValidationFlags flags) internal pure returns (bool) {
+        return ValidationFlags.unwrap(flags) & 0x04 != 0;
     }
 
     function isSignatureValidation(ValidationConfig config) internal pure returns (bool) {
         return ValidationConfig.unwrap(config) & _VALIDATION_FLAG_IS_SIGNATURE != 0;
     }
 
-    function isSignatureValidation(uint8 flags) internal pure returns (bool) {
-        return flags & 0x02 != 0;
+    function isSignatureValidation(ValidationFlags flags) internal pure returns (bool) {
+        return ValidationFlags.unwrap(flags) & 0x02 != 0;
     }
 
     function isUserOpValidation(ValidationConfig config) internal pure returns (bool) {
         return ValidationConfig.unwrap(config) & _VALIDATION_FLAG_IS_USER_OP != 0;
     }
 
-    function isUserOpValidation(uint8 flags) internal pure returns (bool) {
-        return flags & 0x01 != 0;
+    function isUserOpValidation(ValidationFlags flags) internal pure returns (bool) {
+        return ValidationFlags.unwrap(flags) & 0x01 != 0;
     }
 }

--- a/src/libraries/ValidationConfigLib.sol
+++ b/src/libraries/ValidationConfigLib.sol
@@ -3,6 +3,11 @@ pragma solidity ^0.8.26;
 
 import {ModuleEntity, ValidationConfig} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
+// Validation flags layout:
+// 0b00000___ // unused
+// 0b_____A__ // isGlobal
+// 0b______B_ // isSignatureValidation
+// 0b_______C // isUserOpValidation
 type ValidationFlags is uint8;
 
 // Validation config is a packed representation of a validation function and flags for its configuration.

--- a/test/libraries/AccountStorage.t.sol
+++ b/test/libraries/AccountStorage.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.26;
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Test} from "forge-std/src/Test.sol";
+
+import {_ACCOUNT_STORAGE_SLOT} from "../../src/account/AccountStorage.sol";
+import {AccountStorageInitializable} from "../../src/account/AccountStorageInitializable.sol";
+import {MockDiamondStorageContract} from "../mocks/MockDiamondStorageContract.sol";
+
+// Test implementation of AccountStorageInitializable which is contained in ReferenceModularAccount
+contract AccountStorageTest is Test {
+    MockDiamondStorageContract public impl;
+    address public proxy;
+
+    function setUp() external {
+        impl = new MockDiamondStorageContract();
+        proxy = address(new ERC1967Proxy(address(impl), ""));
+    }
+
+    function test_storageSlotImpl() external {
+        // disable initializers sets value to uint8(max)
+        assertEq(uint256(vm.load(address(impl), _ACCOUNT_STORAGE_SLOT)), type(uint8).max);
+
+        // should revert if we try to initialize again
+        vm.expectRevert(AccountStorageInitializable.InvalidInitialization.selector);
+        impl.initialize();
+    }
+
+    function test_storageSlotProxy() external {
+        // before init, proxy's slot should be empty
+        assertEq(uint256(vm.load(proxy, _ACCOUNT_STORAGE_SLOT)), uint256(0));
+
+        MockDiamondStorageContract(proxy).initialize();
+        // post init slot should contains: packed(uint8 initialized = 1, bool initializing = 0)
+        assertEq(uint256(vm.load(proxy, _ACCOUNT_STORAGE_SLOT)), uint256(1));
+    }
+}

--- a/test/libraries/HookConfigLib.t.sol
+++ b/test/libraries/HookConfigLib.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.26;
+
+import {HookConfig, ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {Test} from "forge-std/src/Test.sol";
+
+import {HookConfigLib} from "../../src/libraries/HookConfigLib.sol";
+import {ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
+
+contract HookConfigLibTest is Test {
+    using ModuleEntityLib for ModuleEntity;
+    using HookConfigLib for HookConfig;
+
+    // Tests the packing and unpacking of a hook config with a randomized state
+
+    function testFuzz_hookConfig_packingUnderlying(
+        address addr,
+        uint32 entityId,
+        bool isValidation,
+        bool hasPre,
+        bool hasPost
+    ) public pure {
+        HookConfig hookConfig;
+
+        if (isValidation) {
+            hookConfig = HookConfigLib.packValidationHook(addr, entityId);
+        } else {
+            hookConfig = HookConfigLib.packExecHook(addr, entityId, hasPre, hasPost);
+        }
+
+        assertEq(hookConfig.module(), addr, "module mismatch");
+        assertEq(hookConfig.entityId(), entityId, "entityId mismatch");
+        assertEq(hookConfig.isValidationHook(), isValidation, "isValidation mismatch");
+
+        if (!isValidation) {
+            assertEq(hookConfig.hasPreHook(), hasPre, "hasPre mismatch");
+            assertEq(hookConfig.hasPostHook(), hasPost, "hasPost mismatch");
+        }
+    }
+
+    function testFuzz_hookConfig_packingModuleEntity(
+        ModuleEntity hookFunction,
+        bool isValidation,
+        bool hasPre,
+        bool hasPost
+    ) public pure {
+        HookConfig hookConfig;
+
+        if (isValidation) {
+            hookConfig = HookConfigLib.packValidationHook(hookFunction);
+        } else {
+            hookConfig = HookConfigLib.packExecHook(hookFunction, hasPre, hasPost);
+        }
+
+        assertEq(
+            ModuleEntity.unwrap(hookConfig.moduleEntity()),
+            ModuleEntity.unwrap(hookFunction),
+            "moduleEntity mismatch"
+        );
+        assertEq(hookConfig.isValidationHook(), isValidation, "isValidation mismatch");
+
+        if (!isValidation) {
+            assertEq(hookConfig.hasPreHook(), hasPre, "hasPre mismatch");
+            assertEq(hookConfig.hasPostHook(), hasPost, "hasPost mismatch");
+        }
+    }
+}

--- a/test/libraries/KnowSelectors.t.sol
+++ b/test/libraries/KnowSelectors.t.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.26;
+
+import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
+import {IAccount} from "@eth-infinitism/account-abstraction/interfaces/IAccount.sol";
+import {IPaymaster} from "@eth-infinitism/account-abstraction/interfaces/IPaymaster.sol";
+import {Test} from "forge-std/src/Test.sol";
+
+import {KnownSelectorsLib} from "../../src/libraries/KnownSelectorsLib.sol";
+
+contract KnownSelectorsTest is Test {
+    function test_isNativeFunction() public pure {
+        assertTrue(KnownSelectorsLib.isNativeFunction(IAccount.validateUserOp.selector));
+    }
+
+    function test_isErc4337Function() public pure {
+        assertTrue(KnownSelectorsLib.isErc4337Function(IPaymaster.validatePaymasterUserOp.selector));
+    }
+
+    function test_isIModuleFunction() public pure {
+        assertTrue(KnownSelectorsLib.isIModuleFunction(IModule.moduleId.selector));
+    }
+}

--- a/test/libraries/ModuleEntityLib.t.sol
+++ b/test/libraries/ModuleEntityLib.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/src/Test.sol";
+
+import {ModuleEntity, ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
+
+contract ModuleEntityLibTest is Test {
+    using ModuleEntityLib for ModuleEntity;
+
+    function testFuzz_moduleEntity_packing(address addr, uint32 entityId) public pure {
+        // console.log("addr: ", addr);
+        // console.log("entityId: ", vm.toString(entityId));
+        ModuleEntity fr = ModuleEntityLib.pack(addr, entityId);
+        // console.log("packed: ", vm.toString(ModuleEntity.unwrap(fr)));
+        (address addr2, uint32 entityId2) = ModuleEntityLib.unpack(fr);
+        // console.log("addr2: ", addr2);
+        // console.log("entityId2: ", vm.toString(entityId2));
+        assertEq(addr, addr2);
+        assertEq(entityId, entityId2);
+    }
+
+    function testFuzz_moduleEntity_operators(ModuleEntity a, ModuleEntity b) public pure {
+        assertTrue(a.eq(a));
+        assertTrue(b.eq(b));
+
+        if (ModuleEntity.unwrap(a) == ModuleEntity.unwrap(b)) {
+            assertTrue(a.eq(b));
+            assertTrue(b.eq(a));
+            assertFalse(a.notEq(b));
+            assertFalse(b.notEq(a));
+        } else {
+            assertTrue(a.notEq(b));
+            assertTrue(b.notEq(a));
+            assertFalse(a.eq(b));
+            assertFalse(b.eq(a));
+        }
+    }
+}

--- a/test/libraries/SparseCalldataSegmentLib.t.sol
+++ b/test/libraries/SparseCalldataSegmentLib.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/src/Test.sol";
+
+import {SparseCalldataSegmentLib} from "../../src/libraries/SparseCalldataSegmentLib.sol";
+
+contract SparseCalldataSegmentLibTest is Test {
+    using SparseCalldataSegmentLib for bytes;
+
+    function testFuzz_sparseCalldataSegmentLib_encodeDecode_simple(bytes[] memory segments) public view {
+        bytes memory encoded = _encodeSimple(segments);
+        bytes[] memory decoded = this.decodeSimple(encoded, segments.length);
+
+        assertEq(decoded.length, segments.length, "decoded.length != segments.length");
+
+        for (uint256 i = 0; i < segments.length; i++) {
+            assertEq(decoded[i], segments[i]);
+        }
+    }
+
+    function testFuzz_sparseCalldataSegmentLib_encodeDecode_withIndex(bytes[] memory segments, uint256 indexSeed)
+        public
+        view
+    {
+        // Generate random indices
+        uint8[] memory indices = new uint8[](segments.length);
+        for (uint256 i = 0; i < segments.length; i++) {
+            uint8 nextIndex = uint8(uint256(keccak256(abi.encodePacked(indexSeed, i))));
+            indices[i] = nextIndex;
+        }
+
+        // Encode
+        bytes memory encoded = _encodeWithIndex(segments, indices);
+
+        // Decode
+        (bytes[] memory decodedBodies, uint8[] memory decodedIndices) =
+            this.decodeWithIndex(encoded, segments.length);
+
+        assertEq(decodedBodies.length, segments.length, "decodedBodies.length != segments.length");
+        assertEq(decodedIndices.length, segments.length, "decodedIndices.length != segments.length");
+
+        for (uint256 i = 0; i < segments.length; i++) {
+            assertEq(decodedBodies[i], segments[i]);
+            assertEq(decodedIndices[i], indices[i]);
+        }
+    }
+
+    function _encodeSimple(bytes[] memory segments) internal pure returns (bytes memory) {
+        bytes memory result = "";
+
+        for (uint256 i = 0; i < segments.length; i++) {
+            result = abi.encodePacked(result, uint32(segments[i].length), segments[i]);
+        }
+
+        return result;
+    }
+
+    function _encodeWithIndex(bytes[] memory segments, uint8[] memory indices)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        require(segments.length == indices.length, "segments len != indices len");
+
+        bytes memory result = "";
+
+        for (uint256 i = 0; i < segments.length; i++) {
+            result = abi.encodePacked(result, uint32(segments[i].length + 1), indices[i], segments[i]);
+        }
+
+        return result;
+    }
+
+    function decodeSimple(bytes calldata encoded, uint256 capacityHint) external pure returns (bytes[] memory) {
+        bytes[] memory result = new bytes[](capacityHint);
+
+        bytes calldata remainder = encoded;
+
+        uint256 index = 0;
+        while (remainder.length > 0) {
+            bytes calldata segment;
+            (segment, remainder) = remainder.getNextSegment();
+            result[index] = segment;
+            index++;
+        }
+
+        return result;
+    }
+
+    function decodeWithIndex(bytes calldata encoded, uint256 capacityHint)
+        external
+        pure
+        returns (bytes[] memory, uint8[] memory)
+    {
+        bytes[] memory bodies = new bytes[](capacityHint);
+        uint8[] memory indices = new uint8[](capacityHint);
+
+        bytes calldata remainder = encoded;
+
+        uint256 index = 0;
+        while (remainder.length > 0) {
+            bytes calldata segment;
+            (segment, remainder) = remainder.getNextSegment();
+            bodies[index] = segment.getBody();
+            indices[index] = segment.getIndex();
+            index++;
+        }
+
+        return (bodies, indices);
+    }
+}

--- a/test/libraries/ValidationConfigLib.t.sol
+++ b/test/libraries/ValidationConfigLib.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/src/Test.sol";
+
+import {ModuleEntity, ModuleEntityLib} from "../../src/libraries/ModuleEntityLib.sol";
+import {
+    ValidationConfig, ValidationConfigLib, ValidationFlags
+} from "../../src/libraries/ValidationConfigLib.sol";
+
+contract ValidationConfigLibTest is Test {
+    using ModuleEntityLib for ModuleEntity;
+    using ValidationConfigLib for *;
+
+    // Tests the packing and unpacking of a validation config with a randomized state
+
+    function testFuzz_validationConfig_packingUnderlying(
+        address module,
+        uint32 entityId,
+        bool isGlobal,
+        bool isSignatureValidation,
+        bool isUserOpValidation
+    ) public pure {
+        ValidationConfig validationConfig =
+            ValidationConfigLib.pack(module, entityId, isGlobal, isSignatureValidation, isUserOpValidation);
+
+        // Test unpacking underlying
+        (address module2, uint32 entityId2, ValidationFlags flags2) = validationConfig.unpackUnderlying();
+
+        assertEq(module, module2, "module mismatch");
+        assertEq(entityId, entityId2, "entityId mismatch");
+        assertEq(isGlobal, flags2.isGlobal(), "isGlobal mismatch");
+        assertEq(isSignatureValidation, flags2.isSignatureValidation(), "isSignatureValidation mismatch");
+        assertEq(isUserOpValidation, flags2.isUserOpValidation(), "isUserOpValidation mismatch");
+
+        // Test unpacking to ModuleEntity
+
+        ModuleEntity expectedModuleEntity = ModuleEntityLib.pack(module, entityId);
+
+        (ModuleEntity validationFunction, ValidationFlags flags3) = validationConfig.unpack();
+
+        assertEq(
+            ModuleEntity.unwrap(validationFunction),
+            ModuleEntity.unwrap(expectedModuleEntity),
+            "validationFunction mismatch"
+        );
+        assertEq(isGlobal, flags3.isGlobal(), "isGlobal mismatch");
+        assertEq(isSignatureValidation, flags3.isSignatureValidation(), "isSignatureValidation mismatch");
+        assertEq(isUserOpValidation, flags3.isUserOpValidation(), "isUserOpValidation mismatch");
+
+        // Test individual view functions
+
+        assertEq(validationConfig.module(), module, "module mismatch");
+        assertEq(validationConfig.entityId(), entityId, "entityId mismatch");
+        assertEq(
+            ModuleEntity.unwrap(validationConfig.moduleEntity()),
+            ModuleEntity.unwrap(expectedModuleEntity),
+            "moduleEntity mismatch"
+        );
+        assertEq(validationConfig.isGlobal(), isGlobal, "isGlobal mismatch");
+        assertEq(validationConfig.isSignatureValidation(), isSignatureValidation, "isSignatureValidation mismatch");
+        assertEq(validationConfig.isUserOpValidation(), isUserOpValidation, "isUserOpValidation mismatch");
+    }
+
+    function testFuzz_validationConfig_packingModuleEntity(
+        ModuleEntity validationFunction,
+        bool isGlobal,
+        bool isSignatureValidation,
+        bool isUserOpValidation
+    ) public pure {
+        ValidationConfig validationConfig =
+            ValidationConfigLib.pack(validationFunction, isGlobal, isSignatureValidation, isUserOpValidation);
+
+        // Test unpacking underlying
+
+        (address expectedModule, uint32 expectedEntityId) = validationFunction.unpack();
+
+        (address module, uint32 entityId, ValidationFlags flags2) = validationConfig.unpackUnderlying();
+
+        assertEq(expectedModule, module, "module mismatch");
+        assertEq(expectedEntityId, entityId, "entityId mismatch");
+        assertEq(isGlobal, flags2.isGlobal(), "isGlobal mismatch");
+        assertEq(isSignatureValidation, flags2.isSignatureValidation(), "isSignatureValidation mismatch");
+        assertEq(isUserOpValidation, flags2.isUserOpValidation(), "isUserOpValidation mismatch");
+
+        // Test unpacking to ModuleEntity
+
+        (ModuleEntity validationFunction2, ValidationFlags flags3) = validationConfig.unpack();
+
+        assertEq(
+            ModuleEntity.unwrap(validationFunction),
+            ModuleEntity.unwrap(validationFunction2),
+            "validationFunction mismatch"
+        );
+        assertEq(isGlobal, flags3.isGlobal(), "isGlobal mismatch");
+        assertEq(isSignatureValidation, flags3.isSignatureValidation(), "isSignatureValidation mismatch");
+        assertEq(isUserOpValidation, flags3.isUserOpValidation(), "isUserOpValidation mismatch");
+
+        // Test individual view functions
+
+        assertEq(validationConfig.module(), expectedModule, "module mismatch");
+        assertEq(validationConfig.entityId(), expectedEntityId, "entityId mismatch");
+        assertEq(
+            ModuleEntity.unwrap(validationConfig.moduleEntity()),
+            ModuleEntity.unwrap(validationFunction),
+            "validationFunction mismatch"
+        );
+        assertEq(validationConfig.isGlobal(), isGlobal, "isGlobal mismatch");
+        assertEq(validationConfig.isSignatureValidation(), isSignatureValidation, "isSignatureValidation mismatch");
+        assertEq(validationConfig.isUserOpValidation(), isUserOpValidation, "isUserOpValidation mismatch");
+    }
+}

--- a/test/mocks/MockDiamondStorageContract.sol
+++ b/test/mocks/MockDiamondStorageContract.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.26;
+
+import {AccountStorageInitializable} from "../../src/account/AccountStorageInitializable.sol";
+
+contract MockDiamondStorageContract is AccountStorageInitializable {
+    constructor() {
+        _disableInitializers();
+    }
+
+    // solhint-disable-next-line no-empty-blocks
+    function initialize() external initializer {}
+}


### PR DESCRIPTION
## Motivation

We ported the libraries from the RI, but not the corresponding tests. As we may make changes to the libraries during the optimization process, we should also port the tests.

Additionally, to make sure we're not doing anything unexpected with the value returned as a "validation flags" `uint8` in ValidationConfigLib, we can wrap it in a user-defined value type. This is not used the the account itself, so it does not change performance characteristics.

## Solution

Port the tests and add a user-defined value type for validation flags.