### PR TITLE
build: separate cache dirs for optimized-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 out/
 out-optimized/
 cache/
+cache-optimized/
 node_modules/
 
 # Coverage

--- a/foundry.toml
+++ b/foundry.toml
@@ -30,6 +30,7 @@ via_ir = true
 test = 'src'
 optimizer_runs = 10000
 out = 'out-optimized'
+cache_path = 'cache-optimized'
 
 [profile.optimized-test]
 src = 'test'
@@ -56,6 +57,7 @@ via_ir = true
 test = 'gas'
 optimizer_runs = 10000
 out = 'out-optimized'
+cache_path = 'cache-optimized'
 ffi = true
 isolate = true
 

--- a/test/account/TokenReceiver.t.sol
+++ b/test/account/TokenReceiver.t.sol
@@ -25,7 +25,7 @@ contract TokenReceiverTest is AccountTestBase {
         erc1155.mint(owner1, _NFT_TOKEN_ID, _NFT_TOKEN_COUNT);
     }
 
-    function test_supportedInterfaces() public {
+    function test_supportedInterfaces() public view {
         assertTrue(account1.supportsInterface(type(IERC721Receiver).interfaceId));
         assertTrue(account1.supportsInterface(type(IERC1155Receiver).interfaceId));
     }


### PR DESCRIPTION
## Motivation

There are sometimes excess re-compilations when switching profiles, and giving the different profiles separate cache directories seems to speed things up. It doesn't always work, but is generally a speedup.

## Solution

Give the different compilation profiles separate cache directories.

Also fixes a compiler warning for test function visibility.
