### PR TITLE
refactor: move EP immutable to BaseAccount

### DIFF
--- a/src/account/BaseAccount.sol
+++ b/src/account/BaseAccount.sol
@@ -11,7 +11,13 @@ import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interface
 /// Implementing contracts should override the _validateUserOp function to provide account-specific validation
 /// logic.
 abstract contract BaseAccount is IAccount {
+    IEntryPoint internal immutable _ENTRY_POINT;
+
     error NotEntryPoint();
+
+    constructor(IEntryPoint anEntryPoint) {
+        _ENTRY_POINT = anEntryPoint;
+    }
 
     /// @inheritdoc IAccount
     function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash, uint256 missingAccountFunds)
@@ -34,9 +40,11 @@ abstract contract BaseAccount is IAccount {
         }
     }
 
-    /// @notice Get the EntryPoint address used by this account.
-    /// @return The EntryPoint address.
-    function entryPoint() public view virtual returns (IEntryPoint);
+    /// @notice Gets the entry point for this account
+    /// @return entryPoint The entry point for this account
+    function entryPoint() external view returns (IEntryPoint) {
+        return _ENTRY_POINT;
+    }
 
     /// @notice Account-specific implementation of user op validation. Override this function to define the
     /// account's validation logic.
@@ -47,7 +55,7 @@ abstract contract BaseAccount is IAccount {
 
     /// @notice Revert if the sender is not the EntryPoint.
     function _requireFromEntryPoint() internal view virtual {
-        if (msg.sender != address(entryPoint())) {
+        if (msg.sender != address(_ENTRY_POINT)) {
             revert NotEntryPoint();
         }
     }

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -78,8 +78,6 @@ abstract contract ModularAccountBase is
         EITHER
     }
 
-    IEntryPoint private immutable _ENTRY_POINT;
-
     // keccak256("EIP712Domain(uint256 chainId,address verifyingContract)")
     bytes32 internal constant _DOMAIN_SEPARATOR_TYPEHASH =
         0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218;
@@ -129,8 +127,7 @@ abstract contract ModularAccountBase is
         _doCachedPostExecHooks(postValidatorExecHooks);
     }
 
-    constructor(IEntryPoint anEntryPoint) {
-        _ENTRY_POINT = anEntryPoint;
+    constructor(IEntryPoint anEntryPoint) BaseAccount(anEntryPoint) {
         _disableInitializers();
     }
 
@@ -401,12 +398,6 @@ abstract contract ModularAccountBase is
         wrapNativeFunction
     {
         super.upgradeToAndCall(newImplementation, data);
-    }
-
-    /// @notice Gets the entry point for this account
-    /// @return entryPoint The entry point for this account
-    function entryPoint() public view override returns (IEntryPoint) {
-        return _ENTRY_POINT;
     }
 
     function domainSeparator() public view returns (bytes32) {


### PR DESCRIPTION
## Motivation

To better distribute LOC between BaseAccount and ModularAccount, we can move the immutable EntryPoint var into that contract.

## Solution

Perform that move.

This should be purely an organizational refactor with no performance impact.