### PR TITLE
feat: add SMA known selectors

### DIFF
--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -69,7 +69,7 @@ abstract contract ModuleManagerInternals is IModularAccount {
 
         // Make sure incoming execution function does not collide with any native functions (data are stored on the
         // account implementation contract)
-        if (KnownSelectorsLib.isNativeFunction(selector)) {
+        if (_isNativeFunction(selector)) {
             revert NativeFunctionNotAllowed(selector);
         }
 
@@ -320,5 +320,9 @@ abstract contract ModuleManagerInternals is IModularAccount {
         onUninstallSuccess = onUninstallSuccess && _onUninstall(module, uninstallData);
 
         emit ValidationUninstalled(module, entityId, onUninstallSuccess);
+    }
+
+    function _isNativeFunction(bytes4 selector) internal pure virtual returns (bool) {
+        return KnownSelectorsLib.isNativeFunction(selector);
     }
 }

--- a/src/account/SemiModularAccountBase.sol
+++ b/src/account/SemiModularAccountBase.sol
@@ -11,6 +11,8 @@ import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/Signa
 
 import {DIRECT_CALL_VALIDATION_ENTITYID, FALLBACK_VALIDATION} from "../helpers/Constants.sol";
 import {ModuleEntityLib} from "../libraries/ModuleEntityLib.sol";
+
+import {SemiModularKnownSelectorsLib} from "../libraries/SemiModularKnownSelectorsLib.sol";
 import {ModularAccountBase} from "./ModularAccountBase.sol";
 
 abstract contract SemiModularAccountBase is ModularAccountBase {
@@ -222,5 +224,10 @@ abstract contract SemiModularAccountBase is ModularAccountBase {
             res := keccak256(0, 0x40)
         }
         return res;
+    }
+
+    // Overrides ModuleManagerInternals
+    function _isNativeFunction(bytes4 selector) internal pure override returns (bool) {
+        return SemiModularKnownSelectorsLib.isNativeFunction(selector);
     }
 }

--- a/src/libraries/SemiModularKnownSelectorsLib.sol
+++ b/src/libraries/SemiModularKnownSelectorsLib.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.26;
+
+import {SemiModularAccountBase} from "../account/SemiModularAccountBase.sol";
+import {KnownSelectorsLib} from "./KnownSelectorsLib.sol";
+
+/// @dev Library to help to check if a selector is a know function selector of the SemiModularAccountBase or
+/// ModularAccount contract
+library SemiModularKnownSelectorsLib {
+    function isNativeFunction(bytes4 selector) internal pure returns (bool) {
+        return KnownSelectorsLib.isNativeFunction(selector)
+            || selector == SemiModularAccountBase.updateFallbackSigner.selector
+            || selector == SemiModularAccountBase.setFallbackSignerDisabled.selector
+            || selector == SemiModularAccountBase.isFallbackSignerDisabled.selector
+            || selector == SemiModularAccountBase.getFallbackSigner.selector
+            || selector == SemiModularAccountBase.replaySafeHash.selector;
+    }
+}

--- a/test/libraries/KnowSelectors.t.sol
+++ b/test/libraries/KnowSelectors.t.sol
@@ -6,11 +6,23 @@ import {IAccount} from "@eth-infinitism/account-abstraction/interfaces/IAccount.
 import {IPaymaster} from "@eth-infinitism/account-abstraction/interfaces/IPaymaster.sol";
 import {Test} from "forge-std/src/Test.sol";
 
+import {ModularAccountBase} from "../../src/account/ModularAccountBase.sol";
+import {SemiModularAccountBase} from "../../src/account/SemiModularAccountBase.sol";
 import {KnownSelectorsLib} from "../../src/libraries/KnownSelectorsLib.sol";
+import {SemiModularKnownSelectorsLib} from "../../src/libraries/SemiModularKnownSelectorsLib.sol";
 
 contract KnownSelectorsTest is Test {
     function test_isNativeFunction() public pure {
         assertTrue(KnownSelectorsLib.isNativeFunction(IAccount.validateUserOp.selector));
+        assertTrue(KnownSelectorsLib.isNativeFunction(ModularAccountBase.installValidation.selector));
+    }
+
+    function test_sma_isNativeFunction() public pure {
+        assertTrue(SemiModularKnownSelectorsLib.isNativeFunction(IAccount.validateUserOp.selector));
+        assertTrue(
+            SemiModularKnownSelectorsLib.isNativeFunction(SemiModularAccountBase.getFallbackSigner.selector)
+        );
+        assertTrue(SemiModularKnownSelectorsLib.isNativeFunction(ModularAccountBase.installValidation.selector));
     }
 
     function test_isErc4337Function() public pure {

--- a/test/utils/CustomValidationTestBase.sol
+++ b/test/utils/CustomValidationTestBase.sol
@@ -27,15 +27,10 @@ abstract contract CustomValidationTestBase is AccountTestBase {
         ) = _initialValidationConfig();
 
         if (_isSMATest) {
-            // Short circuit because you cannot install hooks to the fallback validation.
-            // if (validationFunction.eq(FALLBACK_VALIDATION)) {
-            // revert("the fuck");
-            //     return;
-            // }
             account1 =
                 ModularAccount(payable(new ERC1967Proxy{salt: 0}(address(semiModularAccountImplementation), "")));
             _beforeInstallStep(address(account1));
-            // The initializer doesn't work on the SMA
+            // The initializer doesn't work on the SMA.
             vm.prank(address(entryPoint));
             account1.installValidation(
                 ValidationConfigLib.pack(validationFunction, isGlobal, isSignatureValidation, isUserOpValidation),


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

We currently don't have a way to check if a selector is native for SMA selectors.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

This PR adds a new `SemiModularKnownSelectorsLib` library which implements only the `isNativeFunction()` function, which then checks if the selector is a native selector in the `KnownSelectorsLib` library or a native SMA selector. Note that the initializer is not included-- just like in the standard `KnownSelectorsLib`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->