### PR TITLE
fix: detect compiler warnings in CI

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -26,6 +26,7 @@ fail_on_revert = true
 depth = 10
 
 [profile.optimized-build]
+deny_warnings = true
 via_ir = true
 test = 'src'
 optimizer_runs = 10000
@@ -33,9 +34,11 @@ out = 'out-optimized'
 cache_path = 'cache-optimized'
 
 [profile.optimized-test]
+deny_warnings = true
 src = 'test'
 
 [profile.optimized-test-deep]
+deny_warnings = true
 src = 'test'
 
 [profile.optimized-test-deep.fuzz]
@@ -54,6 +57,7 @@ depth = 32
 
 [profile.gas]
 via_ir = true
+deny_warnings = true
 test = 'gas'
 optimizer_runs = 10000
 out = 'out-optimized'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:test": "solhint --max-warnings 0 -c ./config/solhint-test.json './test/**/*.sol'",
     "lint:gas": "solhint --max-warnings 0 -c ./config/solhint-gas.json './gas/**/*.sol'",
     "lint:script": "solhint --max-warnings 0 -c ./config/solhint-script.json './script/**/*.sol'",
-    "prep": "pnpm fmt && forge b && pnpm lint && pnpm test && pnpm gas",
+    "prep": "pnpm fmt && forge b --deny-warnings && pnpm lint && pnpm test && pnpm gas",
     "test": "forge test"
   }
 }

--- a/test/modules/AllowlistModule.t.sol
+++ b/test/modules/AllowlistModule.t.sol
@@ -487,7 +487,7 @@ contract AllowlistModuleTest is CustomValidationTestBase {
     ///   - case 1 - a selector (Counter.setNumber) + address (counters[0]) should match
     ///   - case 2 - wildcard selector (Counter.increment), any address works
     ///   - case 3 - wildcard address (counters[1]), any selector works
-    function _getInputsForTests() internal returns (AllowlistModule.AllowlistInput[] memory) {
+    function _getInputsForTests() internal view returns (AllowlistModule.AllowlistInput[] memory) {
         AllowlistModule.AllowlistInput[] memory inputs = new AllowlistModule.AllowlistInput[](3);
         // case 1 - a selector (Counter.setNumber) + address (counters[0]) should match
         bytes4[] memory selectors1 = new bytes4[](1);


### PR DESCRIPTION
## Motivation

We have a compiler warning committed to `develop`, and have done so a few times in the past by accident.

## Solution

Fix the warning.

Add a check during build that makes the command fail if there is a compiler warning. I thought about adding this to the default profile, but it is easier to compile with warnings while iterating and testing, and clean them up before submitting a PR. So, I put this check only in the non-default build profile (`gas` and the `optimized-*` profiles). I also added the check inline to the `pnpm prep` script.

So, after this PR, it should still be possible to use a default-profile `forge t` to run tests with warnings, but `pnpm prep` should detect the issue before submitting the PR. Technically, I think it's possible for the local check to miss it if it's still in the build cache, but the CI should always detect it.