### PR TITLE
fix: skip fuzz on coverage

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           {
           echo 'COVERAGE<<EOF'
-          forge coverage --no-match-coverage "(test)" | grep '^|'
+          forge coverage --no-match-coverage "(test)" --nmt "(testFuzz|invariant)" | grep '^|'
           echo EOF
           } >> "$GITHUB_OUTPUT"
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "fmt:check": "forge fmt --check && FOUNDRY_PROFILE=gas forge fmt --check",
     "gas": "FOUNDRY_PROFILE=gas forge test -vv",
     "gas:check": "FOUNDRY_PROFILE=gas FORGE_SNAPSHOT_CHECK=true forge test -vv",
-    "lcov": "forge coverage --no-match-coverage '(test)' --report lcov",
+    "lcov": "forge coverage --no-match-coverage '(test)' --nmt '(testFuzz|invariant)' --report lcov",
     "lint": "pnpm lint:src && pnpm lint:test && pnpm lint:gas && pnpm lint:script",
     "lint:src": "solhint --max-warnings 0 -c ./config/solhint-src.json './src/**/*.sol'",
     "lint:test": "solhint --max-warnings 0 -c ./config/solhint-test.json './test/**/*.sol'",

--- a/test/modules/WebauthnValidationModule.t.sol
+++ b/test/modules/WebauthnValidationModule.t.sol
@@ -53,7 +53,7 @@ contract WebauthnValidationModuleTest is AccountTestBase {
         );
     }
 
-    function test_fail_isValidSignature(bytes32 message, uint256 sigR, uint256 sigS) external view {
+    function testFuzz_fail_isValidSignature(bytes32 message, uint256 sigR, uint256 sigS) external view {
         bytes32 challenge = module.replaySafeHash(account, message);
 
         // make sure r, s values isn't the right one by accident. checking 1 should be enough
@@ -105,7 +105,7 @@ contract WebauthnValidationModuleTest is AccountTestBase {
         assertEq(ModularAccountBase(account).validateUserOp(uo, uoHash, 0), _SIG_VALIDATION_PASSED);
     }
 
-    function test_uoValidaton_shouldFail(uint256 sigR, uint256 sigS) external {
+    function testFuzz_uoValidaton_shouldFail(uint256 sigR, uint256 sigS) external {
         PackedUserOperation memory uo;
         uo.sender = account;
         uo.callData = abi.encodeCall(ModularAccountBase.execute, (CODELESS_ADDRESS, 0, new bytes(0)));


### PR DESCRIPTION
## Motivation

With the test introduced in the call buffer optimizations, we now have fuzz tests that take in parameters of type `bytes`. These are generally slow tests, because the fuzzer will generate randomized input parameters that can be very large in size. These tests are useful for catching edge cases, but make the test coverage collection very slow, because of the added overhead of tracing line coverage. In CI, this can take longer than 30 minutes, which slows down dev productivity.

## Solution

Skip fuzz and invariant tests while getting test coverage.

Fix the naming of two tests that are fuzz tests, but didn't have the prefix `testFuzz`.