### PR TITLE
fix: accountstorage coverage, natspec, storage root derivation

### DIFF
--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -9,7 +9,7 @@ import {LinkedListSet, SetValue} from "../libraries/LinkedListSetLib.sol";
 // keccak256(abi.encode(uint256(keccak256("Alchemy.ModularAccount.Storage_V2")) - 1)) & ~bytes32(uint256(0xff))
 bytes32 constant _ACCOUNT_STORAGE_SLOT = 0x596912a710dec01bac203cb0ed2c7e56a2ce6b2a68276967fff6dd57561bdd00;
 
-// Represents data associated with a specifc function selector.
+/// @notice Represents data associated with a specific function selector.
 struct ExecutionData {
     // The module that implements this execution function.
     // If this is a native function, the address should remain address(0).
@@ -25,6 +25,7 @@ struct ExecutionData {
     LinkedListSet executionHooks;
 }
 
+/// @notice Represents data associated with a specific validation function.
 struct ValidationData {
     // Whether or not this validation can be used as a global validation function.
     bool isGlobal;

--- a/src/account/AccountStorageInitializable.sol
+++ b/src/account/AccountStorageInitializable.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.26;
 import {AccountStorage, getAccountStorage} from "./AccountStorage.sol";
 
 /// @title AccountStorageInitializable
-/// @dev Bulk of the impl is lifted from OZ 5.0 Initializible
+/// @notice A contract mixin that provides the functionality of OpenZeppelin's Initializable contract, using the
+/// custom storage layout defined by the AccountStorage struct.
+/// @dev The implementation logic here is modified from OpenZeppelin's Initializable contract from v5.0.
 abstract contract AccountStorageInitializable {
     /**
      * @dev Triggered when the contract has been initialized or reinitialized.
@@ -53,7 +55,7 @@ abstract contract AccountStorageInitializable {
     }
 
     /// @notice Internal function to disable calls to initialization functions
-    /// @dev Reverts if the contract has already been initialized
+    /// @dev Reverts if the contract is currently initializing.
     function _disableInitializers() internal virtual {
         AccountStorage storage $ = getAccountStorage();
         if ($.initializing) {

--- a/test/libraries/AccountStorage.t.sol
+++ b/test/libraries/AccountStorage.t.sol
@@ -35,4 +35,9 @@ contract AccountStorageTest is Test {
         // post init slot should contains: packed(uint8 initialized = 1, bool initializing = 0)
         assertEq(uint256(vm.load(proxy, _ACCOUNT_STORAGE_SLOT)), uint256(1));
     }
+
+    function test_accountStorage_revertOnBadDisableInitializers() public {
+        vm.expectRevert(AccountStorageInitializable.InvalidInitialization.selector);
+        MockDiamondStorageContract(proxy).badDisableInitializers();
+    }
 }

--- a/test/mocks/MockDiamondStorageContract.sol
+++ b/test/mocks/MockDiamondStorageContract.sol
@@ -10,4 +10,9 @@ contract MockDiamondStorageContract is AccountStorageInitializable {
 
     // solhint-disable-next-line no-empty-blocks
     function initialize() external initializer {}
+
+    // Can't call disable initializers during initialization.
+    function badDisableInitializers() external initializer {
+        _disableInitializers();
+    }
 }


### PR DESCRIPTION
## Motivation

Cleanup pass on `AccountStorage.sol` and `AccountStorageInitializable.sol`.

## Solution

Expand and clarify natspec.

Test an edge case for the disableInitializers logic (impossible to reach in MA/SMA code).

Update the derivation of the storage root. Previously, we were not actually using ERC-7201, and the hash calculation was wrong. Both of those are now corrected, and the derivation matches the pattern used in MAv1, but with the major version number increased to 2.