### PR TITLE
fix: rename ValidationData and ExecutionData

### DIFF
--- a/src/account/AccountStorage.sol
+++ b/src/account/AccountStorage.sol
@@ -10,7 +10,7 @@ import {LinkedListSet, SetValue} from "../libraries/LinkedListSetLib.sol";
 bytes32 constant _ACCOUNT_STORAGE_SLOT = 0x596912a710dec01bac203cb0ed2c7e56a2ce6b2a68276967fff6dd57561bdd00;
 
 /// @notice Represents data associated with a specific function selector.
-struct ExecutionData {
+struct ExecutionStorage {
     // The module that implements this execution function.
     // If this is a native function, the address should remain address(0).
     address module;
@@ -26,7 +26,7 @@ struct ExecutionData {
 }
 
 /// @notice Represents data associated with a specific validation function.
-struct ValidationData {
+struct ValidationStorage {
     // Whether or not this validation can be used as a global validation function.
     bool isGlobal;
     // Whether or not this validation is allowed to validate ERC-1271 signatures.
@@ -53,9 +53,9 @@ struct AccountStorage {
     uint8 initialized;
     bool initializing;
     // Execution functions and their associated functions.
-    mapping(bytes4 selector => ExecutionData) executionData;
+    mapping(bytes4 selector => ExecutionStorage) executionStorage;
     // Validation functions and their associated functions.
-    mapping(ModuleEntity validationFunction => ValidationData) validationData;
+    mapping(ModuleEntity validationFunction => ValidationStorage) validationStorage;
     // Module-defined ERC-165 interfaces installed on the account.
     mapping(bytes4 => uint256) supportedIfaces;
     // Nonce usage state for deferred actions.

--- a/src/account/ModularAccountView.sol
+++ b/src/account/ModularAccountView.sol
@@ -15,7 +15,7 @@ import {
 } from "@erc6900/reference-implementation/interfaces/IModularAccountView.sol";
 
 import {MemManagementLib} from "../libraries/MemManagementLib.sol";
-import {ExecutionData, ValidationData, getAccountStorage} from "./AccountStorage.sol";
+import {ExecutionStorage, ValidationStorage, getAccountStorage} from "./AccountStorage.sol";
 
 abstract contract ModularAccountView is IModularAccountView {
     /// @inheritdoc IModularAccountView
@@ -29,12 +29,12 @@ abstract contract ModularAccountView is IModularAccountView {
             data.module = address(this);
             data.allowGlobalValidation = true;
         } else {
-            ExecutionData storage executionData = getAccountStorage().executionData[selector];
-            data.module = executionData.module;
-            data.skipRuntimeValidation = executionData.skipRuntimeValidation;
-            data.allowGlobalValidation = executionData.allowGlobalValidation;
+            ExecutionStorage storage executionStorage = getAccountStorage().executionStorage[selector];
+            data.module = executionStorage.module;
+            data.skipRuntimeValidation = executionStorage.skipRuntimeValidation;
+            data.allowGlobalValidation = executionStorage.allowGlobalValidation;
 
-            HookConfig[] memory hooks = MemManagementLib.loadExecHooks(executionData);
+            HookConfig[] memory hooks = MemManagementLib.loadExecHooks(executionStorage);
             MemManagementLib.reverseArr(hooks);
             data.executionHooks = hooks;
         }
@@ -47,18 +47,18 @@ abstract contract ModularAccountView is IModularAccountView {
         override
         returns (ValidationDataView memory data)
     {
-        ValidationData storage validationData = getAccountStorage().validationData[validationFunction];
-        data.isGlobal = validationData.isGlobal;
-        data.isSignatureValidation = validationData.isSignatureValidation;
-        data.isUserOpValidation = validationData.isUserOpValidation;
-        data.validationHooks = MemManagementLib.loadValidationHooks(validationData);
+        ValidationStorage storage validationStorage = getAccountStorage().validationStorage[validationFunction];
+        data.isGlobal = validationStorage.isGlobal;
+        data.isSignatureValidation = validationStorage.isSignatureValidation;
+        data.isUserOpValidation = validationStorage.isUserOpValidation;
+        data.validationHooks = MemManagementLib.loadValidationHooks(validationStorage);
         MemManagementLib.reverseArr(data.validationHooks);
 
-        HookConfig[] memory hooks = MemManagementLib.loadExecHooks(validationData);
+        HookConfig[] memory hooks = MemManagementLib.loadExecHooks(validationStorage);
         MemManagementLib.reverseArr(hooks);
         data.executionHooks = hooks;
 
-        bytes4[] memory selectors = MemManagementLib.loadSelectors(validationData);
+        bytes4[] memory selectors = MemManagementLib.loadSelectors(validationStorage);
         MemManagementLib.reverseArr(selectors);
         data.selectors = selectors;
     }

--- a/src/libraries/MemManagementLib.sol
+++ b/src/libraries/MemManagementLib.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.26;
 
 import {HookConfig} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 
-import {ExecutionData, ValidationData} from "../account/AccountStorage.sol";
+import {ExecutionStorage, ValidationStorage} from "../account/AccountStorage.sol";
 import {LinkedListSet, LinkedListSetLib, SENTINEL_VALUE, SetValue} from "./LinkedListSetLib.sol";
 
 type MemSnapshot is uint256;
 
 library MemManagementLib {
-    function loadExecHooks(ExecutionData storage execData, ValidationData storage valData)
+    function loadExecHooks(ExecutionStorage storage execData, ValidationStorage storage valData)
         internal
         view
         returns (HookConfig[] memory hooks)
@@ -79,7 +79,7 @@ library MemManagementLib {
         return hooks;
     }
 
-    function loadExecHooks(ExecutionData storage execData) internal view returns (HookConfig[] memory) {
+    function loadExecHooks(ExecutionStorage storage execData) internal view returns (HookConfig[] memory) {
         HookConfig[] memory hooks;
 
         SetValue[] memory hooksSet = LinkedListSetLib.getAll(execData.executionHooks);
@@ -93,19 +93,19 @@ library MemManagementLib {
         return hooks;
     }
 
-    function loadExecHooks(ValidationData storage valData) internal view returns (HookConfig[] memory) {
+    function loadExecHooks(ValidationStorage storage valData) internal view returns (HookConfig[] memory) {
         uint256 validationAssocHooksLength = valData.executionHookCount;
 
         return _loadValidationAssociatedHooks(validationAssocHooksLength, valData.executionHooks);
     }
 
-    function loadValidationHooks(ValidationData storage valData) internal view returns (HookConfig[] memory) {
+    function loadValidationHooks(ValidationStorage storage valData) internal view returns (HookConfig[] memory) {
         uint256 validationHookCount = valData.validationHookCount;
 
         return _loadValidationAssociatedHooks(validationHookCount, valData.validationHooks);
     }
 
-    function loadSelectors(ValidationData storage valData) internal view returns (bytes4[] memory selectors) {
+    function loadSelectors(ValidationStorage storage valData) internal view returns (bytes4[] memory selectors) {
         SetValue[] memory selectorsSet = LinkedListSetLib.getAll(valData.selectors);
 
         // SetValue is internally a bytes30, and both bytes4 and bytes30 are left-aligned. This cast is safe so
@@ -167,7 +167,7 @@ library MemManagementLib {
     }
 
     // Used to load both pre-validation hooks and pre-execution hooks, associated with a validation function.
-    // The caller must first get the length of the hooks from the ValidationData struct.
+    // The caller must first get the length of the hooks from the ValidationStorage struct.
     function _loadValidationAssociatedHooks(uint256 hookCount, LinkedListSet storage hooks)
         private
         view

--- a/test/utils/StorageAccesses.sol
+++ b/test/utils/StorageAccesses.sol
@@ -83,14 +83,14 @@ library StorageAccesses {
 
         uint256 root = uint256(_ACCOUNT_STORAGE_SLOT);
 
-        uint256 validationDataMappingSlot = root + 2;
-        uint256 validationDataSlot =
-            getMappingEntrySlot(validationDataMappingSlot, uint256(bytes32(ModuleEntity.unwrap(validation))));
+        uint256 validationStorageMappingSlot = root + 2;
+        uint256 validationStorageSlot =
+            getMappingEntrySlot(validationStorageMappingSlot, uint256(bytes32(ModuleEntity.unwrap(validation))));
 
-        slots[0] = bytes32(validationDataSlot);
+        slots[0] = bytes32(validationStorageSlot);
         names[0] = "Validation data slot (contains flags)";
 
-        uint256 preValidationHooksLengthSlot = validationDataSlot + 1;
+        uint256 preValidationHooksLengthSlot = validationStorageSlot + 1;
         slots[1] = bytes32(preValidationHooksLengthSlot);
         names[1] = "Pre-validation hooks length slot";
 
@@ -98,12 +98,12 @@ library StorageAccesses {
         slots[2] = bytes32(preValidationHooksContentSlot);
         names[2] = "Pre-validation hooks content slot";
 
-        uint256 executionHooksMappingSlot = validationDataSlot + 2;
+        uint256 executionHooksMappingSlot = validationStorageSlot + 2;
         uint256 executionHooksFirstElementSlot = getMappingEntrySlot(executionHooksMappingSlot, uint256(1));
         slots[3] = bytes32(executionHooksFirstElementSlot);
         names[3] = "Execution hooks first element slot";
 
-        uint256 selectorsMappingSlot = validationDataSlot + 3;
+        uint256 selectorsMappingSlot = validationStorageSlot + 3;
         uint256 selectorsFirstElementSlot = getMappingEntrySlot(selectorsMappingSlot, uint256(1));
         slots[4] = bytes32(selectorsFirstElementSlot);
         names[4] = "Selectors first element slot";
@@ -111,14 +111,14 @@ library StorageAccesses {
         slots[5] = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
         names[5] = "ERC-1967 proxy implementation slot";
 
-        uint256 executionDataMappingSlot = root + 1;
-        uint256 executionDataSlot =
-            getMappingEntrySlot(executionDataMappingSlot, uint256(bytes32(executionSelector)));
+        uint256 executionStorageMappingSlot = root + 1;
+        uint256 executionStorageSlot =
+            getMappingEntrySlot(executionStorageMappingSlot, uint256(bytes32(executionSelector)));
 
-        slots[6] = bytes32(executionDataSlot);
+        slots[6] = bytes32(executionStorageSlot);
         names[6] = "Execution data slot (contains module address and flags)";
 
-        uint256 selectorExecutionHooksMappingSlot = executionDataSlot + 1;
+        uint256 selectorExecutionHooksMappingSlot = executionStorageSlot + 1;
         uint256 selectorExecutionHooksFirstElementSlot =
             getMappingEntrySlot(selectorExecutionHooksMappingSlot, uint256(1));
         slots[7] = bytes32(selectorExecutionHooksFirstElementSlot);


### PR DESCRIPTION
To reduce confusion with ERC-4337's `validationData`.