### PR TITLE
fix: BaseAccount coverage and comments

### DIFF
--- a/src/account/BaseAccount.sol
+++ b/src/account/BaseAccount.sol
@@ -22,7 +22,6 @@ abstract contract BaseAccount is IAccount {
     /// @inheritdoc IAccount
     function validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash, uint256 missingAccountFunds)
         external
-        virtual
         override
         returns (uint256 validationData)
     {
@@ -31,7 +30,6 @@ abstract contract BaseAccount is IAccount {
         validationData = _validateUserOp(userOp, userOpHash);
 
         // Pay the prefund if necessary.
-        // todo: storage-warming optimization if nonzero requiredPrefund
         assembly ("memory-safe") {
             if missingAccountFunds {
                 // Ignore failure (it's EntryPoint's job to verify, not the account's).
@@ -54,7 +52,7 @@ abstract contract BaseAccount is IAccount {
         returns (uint256 validationData);
 
     /// @notice Revert if the sender is not the EntryPoint.
-    function _requireFromEntryPoint() internal view virtual {
+    function _requireFromEntryPoint() internal view {
         if (msg.sender != address(_ENTRY_POINT)) {
             revert NotEntryPoint();
         }

--- a/test/account/ModularAccount.t.sol
+++ b/test/account/ModularAccount.t.sol
@@ -14,6 +14,7 @@ import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
+import {BaseAccount} from "../../src/account/BaseAccount.sol";
 import {ModularAccount} from "../../src/account/ModularAccount.sol";
 import {ModularAccountBase} from "../../src/account/ModularAccountBase.sol";
 import {ModuleManagerInternals} from "../../src/account/ModuleManagerInternals.sol";
@@ -556,6 +557,19 @@ contract ModularAccountTest is AccountTestBase {
         // re-deploying with same salt should revert
         vm.prank(address(entryPoint));
         account1.performCreate2(0, initCode, salt);
+    }
+
+    function test_assertCallerEntryPoint() public withSMATest {
+        PackedUserOperation memory userOp;
+
+        // Prank a non-EP address
+        vm.prank(beneficiary);
+        vm.expectRevert(BaseAccount.NotEntryPoint.selector);
+        account1.validateUserOp(userOp, bytes32(0), 0);
+
+        vm.prank(beneficiary);
+        vm.expectRevert(BaseAccount.NotEntryPoint.selector);
+        account1.executeUserOp(userOp, bytes32(0));
     }
 
     // Internal Functions


### PR DESCRIPTION
## Motivation

Cleanup pass on `BaseAccount.sol`.

## Solution

Remove virtual keyword where unused.

Remove unneeded todo comment (this is already done whenever the gas limit is > actual usage by any amount, which covers almost all cases due to the client-added buffer.

Added a test for asserting reverts on non-EntryPoint callers.

