### PR TITLE
chore: update forge-std and update deprecated cheatcodes

### DIFF
--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -44,7 +44,7 @@ contract AccountExecHooksTest is AccountTestBase {
     event ReceivedCall(bytes msgData, uint256 msgValue);
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         _allowTestDirectCalls();
 
         _m1.executionFunctions.push(

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -36,7 +36,7 @@ contract AccountReturnDataTest is AccountTestBase {
     ResultConsumerModule public resultConsumerModule;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         _transferOwnershipToTest();
 
         regularResultContract = new RegularResultContract();

--- a/test/account/DeferredAction.t.sol
+++ b/test/account/DeferredAction.t.sol
@@ -46,7 +46,7 @@ contract DeferredActionTest is AccountTestBase {
     MockModule public mockModule;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         erc20 = new MockERC20();
         paymaster = new MockTokenPaymaster(erc20, entryPoint);
 

--- a/test/account/DeferredValidation.t.sol
+++ b/test/account/DeferredValidation.t.sol
@@ -46,7 +46,7 @@ contract DeferredValidationTest is AccountTestBase {
     uint256 internal _newSignerKey;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         _encodedCall = abi.encodeCall(ModularAccountBase.execute, (makeAddr("dead"), 0, ""));
         _deferredValidation = ModuleEntityLib.pack(address(_deploySingleSignerValidationModule()), 0);
         uint32 entityId = 0;

--- a/test/account/DirectCallsFromModule.t.sol
+++ b/test/account/DirectCallsFromModule.t.sol
@@ -52,7 +52,7 @@ contract DirectCallsFromModuleTest is AccountTestBase {
     }
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         _module = new DirectCallModule();
         assertFalse(_module.preHookRan());
         assertFalse(_module.postHookRan());

--- a/test/account/GlobalValidationTest.t.sol
+++ b/test/account/GlobalValidationTest.t.sol
@@ -38,7 +38,7 @@ contract GlobalValidationTest is AccountTestBase {
     ModularAccount public account2;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         (owner2, owner2Key) = makeAddrAndKey("owner2");
 
         // Compute counterfactual address

--- a/test/account/HookOrdering.t.sol
+++ b/test/account/HookOrdering.t.sol
@@ -52,7 +52,7 @@ contract HookOrderingTest is AccountTestBase {
     ModuleEntity public orderCheckerValidationEntity;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         hookOrderChecker = new HookOrderCheckerModule();
     }
 

--- a/test/account/ModularAccount.t.sol
+++ b/test/account/ModularAccount.t.sol
@@ -72,7 +72,7 @@ contract ModularAccountTest is AccountTestBase {
     event ReceivedCall(bytes msgData, uint256 msgValue);
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         mockExecutionInstallationModule = new MockExecutionInstallationModule();
 
         (owner2, owner2Key) = makeAddrAndKey("owner2");

--- a/test/account/ModularAccountView.t.sol
+++ b/test/account/ModularAccountView.t.sol
@@ -41,7 +41,7 @@ contract ModularAccountViewTest is CustomValidationTestBase {
     ModuleEntity public comprehensiveModuleValidation;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         comprehensiveModule = new ComprehensiveModule();
         comprehensiveModuleValidation =
             ModuleEntityLib.pack(address(comprehensiveModule), uint32(ComprehensiveModule.EntityId.VALIDATION));

--- a/test/account/PerHookData.t.sol
+++ b/test/account/PerHookData.t.sol
@@ -45,7 +45,7 @@ contract PerHookDataTest is CustomValidationTestBase {
     uint32 internal constant _PRE_HOOK_ENTITY_ID_2 = 1;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         _counter = new Counter();
 
         _accessControlHookModule = new MockAccessControlHookModule();

--- a/test/account/PermittedCallPermissions.t.sol
+++ b/test/account/PermittedCallPermissions.t.sol
@@ -29,7 +29,7 @@ contract PermittedCallPermissionsTest is AccountTestBase {
     PermittedCallerModule public permittedCallerModule;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         _transferOwnershipToTest();
         resultCreatorModule = new ResultCreatorModule();
 

--- a/test/account/ReplaceModule.t.sol
+++ b/test/account/ReplaceModule.t.sol
@@ -50,7 +50,7 @@ contract UpgradeModuleTest is AccountTestBase {
     event ReceivedCall(bytes msgData, uint256 msgValue);
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
     }
 
     function test_upgradeModuleExecutionFunction() public withSMATest {

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -36,7 +36,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
     ModuleEntity public comprehensiveModuleValidation;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         // install the comprehensive module to get new exec functions with different validations configured.
 
         comprehensiveModule = new ComprehensiveModule();

--- a/test/account/SemiModularAccountDirectCall.t.sol
+++ b/test/account/SemiModularAccountDirectCall.t.sol
@@ -37,7 +37,7 @@ contract SemiModularAccountDirectCallTest is AccountTestBase {
     ModuleEntity internal _fallbackDirectCallModuleEntity;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         _module = new MockSMADirectFallbackModule();
         _directCallModuleEntity = ModuleEntityLib.pack(address(_module), DIRECT_CALL_VALIDATION_ENTITYID);
 

--- a/test/account/TokenReceiver.t.sol
+++ b/test/account/TokenReceiver.t.sol
@@ -31,7 +31,7 @@ contract TokenReceiverTest is AccountTestBase {
     uint256 internal constant _NFT_TOKEN_COUNT = 10;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         // Compute counterfactual address
         // account1 = factory.createAccount(owner1, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID);
         // vm.deal(address(account1), 100 ether);

--- a/test/account/UpgradeToSma.t.sol
+++ b/test/account/UpgradeToSma.t.sol
@@ -45,7 +45,7 @@ contract UpgradeToSmaTest is AccountTestBase {
     uint256 public transferAmount;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         smaStorageImpl = address(new SemiModularAccountStorageOnly(entryPoint));
         (owner2, owner2Key) = makeAddrAndKey("owner2");
         transferAmount = 0.1 ether;

--- a/test/account/ValidationIntersection.t.sol
+++ b/test/account/ValidationIntersection.t.sol
@@ -45,7 +45,7 @@ contract ValidationIntersectionTest is AccountTestBase {
     ModuleEntity public twoHookValidation;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         noHookModule = new MockUserOpValidationModule();
         oneHookModule = new MockUserOpValidation1HookModule();
         twoHookModule = new MockUserOpValidation2HookModule();

--- a/test/modules/AllowlistERC20TokenLimit.t.sol
+++ b/test/modules/AllowlistERC20TokenLimit.t.sol
@@ -49,7 +49,7 @@ contract AllowlistERC20TokenLimitTest is AccountTestBase {
     uint32 public constant ENTITY_ID = 1;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         // Set up a validator with hooks from the erc20 spend limit module attached
 
         erc20 = new MockERC20();

--- a/test/modules/AllowlistModule.t.sol
+++ b/test/modules/AllowlistModule.t.sol
@@ -301,14 +301,14 @@ contract AllowlistModuleTest is CustomValidationTestBase {
 
         // assert that the user op would succeed
 
-        uint256 stateSnapshot = vm.snapshot();
+        uint256 stateSnapshot = vm.snapshotState();
 
         vm.prank(beneficiary);
         entryPoint.handleOps(userOps, beneficiary);
 
         assertEq(counters[0].number(), 1);
 
-        vm.revertTo(stateSnapshot);
+        vm.revertToState(stateSnapshot);
 
         // Now, assert it fails with >0 validation data.
 

--- a/test/modules/NativeTokenLimitModule.t.sol
+++ b/test/modules/NativeTokenLimitModule.t.sol
@@ -48,7 +48,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
     uint32 public entityId = 0;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         // Set up a validator with hooks from the gas spend limit module attached
 
         ModuleEntity[] memory preValidationHooks = new ModuleEntity[](1);
@@ -321,11 +321,11 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
         uos[0] = _getPackedUO(200_000, 200_000, 200_000, 1, _getExecuteWithValue(5 ether));
 
         // Assert that this would pass
-        uint256 stateSnapshot = vm.snapshot();
+        uint256 stateSnapshot = vm.snapshotState();
         vm.prank(beneficiary);
         entryPoint.handleOps(uos, beneficiary);
 
-        vm.revertTo(stateSnapshot);
+        vm.revertToState(stateSnapshot);
 
         // Now, assert it fails with >0 validation data.
 

--- a/test/modules/PaymasterGuardModule.t.sol
+++ b/test/modules/PaymasterGuardModule.t.sol
@@ -43,7 +43,7 @@ contract PaymasterGuardModuleTest is AccountTestBase {
     uint32 public constant ENTITY_ID = TEST_DEFAULT_VALIDATION_ENTITY_ID;
 
     function setUp() public override {
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
         account = payable(makeAddr("account"));
         paymaster1 = payable(makeAddr("paymaster1"));
         paymaster2 = payable(makeAddr("paymaster2"));
@@ -111,13 +111,13 @@ contract PaymasterGuardModuleTest is AccountTestBase {
 
         // Assert that it would succeed
 
-        uint256 stateSnapshot = vm.snapshot();
+        uint256 stateSnapshot = vm.snapshotState();
 
         uint256 res = module.preUserOpValidationHook(ENTITY_ID, uo, bytes32(0));
 
         assertEq(res, 0);
 
-        vm.revertTo(stateSnapshot);
+        vm.revertToState(stateSnapshot);
 
         // Now, test with validation hook data, and expect failure
 

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -80,7 +80,7 @@ abstract contract AccountTestBase is OptimizedTest, ModuleSignatureUtils {
     modifier withSMATest() {
         _;
 
-        vm.revertTo(_revertSnapshot);
+        vm.revertToState(_revertSnapshot);
 
         _switchToSMA();
 
@@ -122,7 +122,7 @@ abstract contract AccountTestBase is OptimizedTest, ModuleSignatureUtils {
         _signerValidation =
             ModuleEntityLib.pack(address(singleSignerValidationModule), TEST_DEFAULT_VALIDATION_ENTITY_ID);
 
-        _revertSnapshot = vm.snapshot();
+        _revertSnapshot = vm.snapshotState();
     }
 
     function _runExecUserOp(address target, bytes memory callData) internal {


### PR DESCRIPTION
## Motivation

We are currently getting warnings during test runs when using `vm.snapshot` and `vm.revertTo`, as these are now deprecated and replaced with `vm.snapshotState` and `vm.revertToState`.

## Solution

Swap the deprecated cheatcodes for their non-deprecated replacements.

~~Update forge-std to `master` and replace usage of the deprecated opcodes. `forge-std`'s latest release `v1.9.3` does not yet support the non-deprecated cheatcodes.~~

Update: since then, forge-std v1.9.4 has been released with this included in the changes. The PR has been updated to use this tagged version, rather than an arbitrary commit.