### PR TITLE
chore: update ci for new foundry formatting

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
          {
          echo 'NEWSIZES<<EOF'
-         FOUNDRY_PROFILE=optimized-build forge b --sizes | grep '^|' | grep -v -e '|       17 |' -e 'Lib'
+         FOUNDRY_PROFILE=optimized-build forge b --sizes | grep '^|' | grep -v -e '|               17 |' -e 'Lib'
          echo EOF
          } >> "$GITHUB_OUTPUT"
 
@@ -60,7 +60,7 @@ jobs:
         run: |
          {
          echo 'OLDSIZES<<EOF'
-         FOUNDRY_PROFILE=optimized-build forge b --sizes | grep '^|' | grep -v -e '|       17 |' -e 'Lib'
+         FOUNDRY_PROFILE=optimized-build forge b --sizes | grep '^|' | grep -v -e '|               17 |' -e 'Lib'
          echo EOF
          } >> "$GITHUB_OUTPUT"
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:gas": "solhint --max-warnings 0 -c ./config/solhint-gas.json './gas/**/*.sol'",
     "lint:script": "solhint --max-warnings 0 -c ./config/solhint-script.json './script/**/*.sol'",
     "prep": "pnpm fmt && forge b --deny-warnings && pnpm lint && pnpm test && pnpm gas",
-    "sizes": "FOUNDRY_PROFILE=optimized-build forge b --sizes | grep '^|' | grep -v -e '|       17 |' -e 'Lib'",
+    "sizes": "FOUNDRY_PROFILE=optimized-build forge b --sizes | grep '^|' | grep -v -e '|               17 |' -e 'Lib'",
     "test": "forge test"
   }
 }


### PR DESCRIPTION
## Motivation

Our simple way of filtering out library contracts in the "PR report" CI action has stopped working due to an update to foundry that changes the table width formatting.

## Solution

While we could implement a more in-depth filtering method that reads the source files to determine what to filter, we can also just update the spacing on these filters. For the time being, this seems simpler.