### PR TITLE
test: [QS ALC-9] add more tests for insufficient return data and clarifying comments

### DIFF
--- a/src/libraries/ExecutionLib.sol
+++ b/src/libraries/ExecutionLib.sol
@@ -258,6 +258,7 @@ library ExecutionLib {
 
             success :=
                 and(
+                    // Yul evaluates expressions from right to left, so `returndatasize` will evaluate after `call`.
                     gt(returndatasize(), 0x1f),
                     call(
                         // If gas is the leftmost item before the call, it *should* be placed immediately before the
@@ -1020,6 +1021,8 @@ library ExecutionLib {
             // Perform the call
             success :=
                 and(
+                    // Yul evaluates expressions from right to left, so `returndatasize` will evaluate after
+                    // `staticcall`.
                     gt(returndatasize(), 0x1f),
                     staticcall(
                         gas(),


### PR DESCRIPTION
## Motivation

Addresses QS ALC-9.

This is not an issue, because yul expressions evaluate right-to-left: https://docs.soliditylang.org/en/v0.8.27/yul.html#function-calls

> For built-in functions of the EVM, functional expressions can be directly translated to a stream of opcodes: You just read the expression from right to left to obtain the opcodes.

## Solution

Add additional tests that verify this behavior. There was one unit test that already checked this behavior in `test_uoCallBuffer_shortReturnData`, which only tested for short return data coming from a pre-validation hook, so this PR adds tests for user op validation and for signature validation.

Also adds clarifying comments in ExecutionLib.

