### PR TITLE
fix: [CL ALCHEMY-001] validation applicability check in deferred action

### DIFF
--- a/gas-snapshots/ModularAccount.json
+++ b/gas-snapshots/ModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "161531",
   "UserOp_UseSessionKey_Case1_Counter": "195236",
   "UserOp_UseSessionKey_Case1_Token": "226220",
-  "UserOp_deferredValidation": "257078"
+  "UserOp_deferredValidation": "257289"
 }

--- a/gas-snapshots/SemiModularAccount.json
+++ b/gas-snapshots/SemiModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "156773",
   "UserOp_UseSessionKey_Case1_Counter": "195464",
   "UserOp_UseSessionKey_Case1_Token": "226460",
-  "UserOp_deferredValidation": "253524"
+  "UserOp_deferredValidation": "253735"
 }

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -491,8 +491,8 @@ abstract contract ModularAccountBase is
         ValidationConfig uoValidation = ValidationConfig.wrap(bytes25(encodedData[38:63]));
 
         // Check if the outer validation applies to the function call
-        _checkIfValidationAppliesSelector(
-            bytes4(encodedData[63:67]),
+        _checkIfValidationAppliesCallData(
+            encodedData[63:],
             sigValidation,
             isGlobalValidation ? ValidationCheckingType.GLOBAL : ValidationCheckingType.SELECTOR
         );


### PR DESCRIPTION
## Motivation

Addresses CL ALCHEMY-001.

In `_validateDeferredActionAndSetNonce`, the incorrect validation applicability checking function was used, which only verified the selector, rather than considering the allowed pattern of batching using self-calls.

Note that we can't adopt the suggested remediation due to the requirement of supporting calls to `approve` on token contracts during a user op with initcode. See this test file for a sample case: https://github.com/alchemyplatform/modular-account/blob/develop/test/account/DeferredAction.t.sol#L61.

## Solution

Update the deferred action checking logic to use `_checkIfValidationAppliesCallData`, which performs the necessary checks over self-calls.

Also add a test verifying that the validation applicability check for self-calls is enforced.