### PR TITLE
fix: [QS-ALC-2] add non zero address check for paymaster in modules

### DIFF
--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -107,7 +107,7 @@ abstract contract ModularAccountBase is
 
     // Wraps execution of a native function with runtime validation and hooks
     // Used for upgradeTo, upgradeToAndCall, execute, executeBatch, installExecution, uninstallExecution,
-    // performCreate, performCreate2
+    // performCreate
     modifier wrapNativeFunction() {
         DensePostHookData postHookData = _checkPermittedCallerAndAssociatedHooks();
 

--- a/src/modules/permissions/NativeTokenLimitModule.sol
+++ b/src/modules/permissions/NativeTokenLimitModule.sol
@@ -73,10 +73,12 @@ contract NativeTokenLimitModule is ModuleBase, IExecutionHookModule, IValidation
             if (paymaster == address(0)) {
                 revert InvalidPaymaster();
             } else if (specialPaymasters[paymaster][msg.sender]) {
-                _decreaseLimit(entityId, userOp);
+                // Special paymaster specified, decrease limit
+                _decreaseLimit(entityId, userOp, true);
             }
         } else {
-            _decreaseLimit(entityId, userOp);
+            // No paymaster specified, decrease limit
+            _decreaseLimit(entityId, userOp, false);
         }
 
         return 0;
@@ -154,12 +156,12 @@ contract NativeTokenLimitModule is ModuleBase, IExecutionHookModule, IValidation
         return interfaceId == type(IExecutionHookModule).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    function _decreaseLimit(uint32 entityId, PackedUserOperation calldata userOp) internal {
+    function _decreaseLimit(uint32 entityId, PackedUserOperation calldata userOp, bool hasPaymaster) internal {
         uint256 vgl = UserOperationLib.unpackVerificationGasLimit(userOp);
         uint256 cgl = UserOperationLib.unpackCallGasLimit(userOp);
         uint256 pvgl;
         uint256 ppogl;
-        if (userOp.paymasterAndData.length > 0) {
+        if (hasPaymaster) {
             // Can skip the EP length check here since it would have reverted there if it was invalid
             (, pvgl, ppogl) = UserOperationLib.unpackPaymasterStaticFields(userOp.paymasterAndData);
         }

--- a/src/modules/permissions/NativeTokenLimitModule.sol
+++ b/src/modules/permissions/NativeTokenLimitModule.sol
@@ -46,6 +46,7 @@ contract NativeTokenLimitModule is ModuleBase, IExecutionHookModule, IValidation
     mapping(address paymaster => mapping(address account => bool allowed)) public specialPaymasters;
 
     error ExceededNativeTokenLimit();
+    error InvalidPaymaster();
 
     /// @notice Update the native token limit for a specific entity
     /// @param entityId The entity id
@@ -68,27 +69,17 @@ contract NativeTokenLimitModule is ModuleBase, IExecutionHookModule, IValidation
         returns (uint256)
     {
         // Decrease limit only if no paymaster is used, or if its a special paymaster
-        if (
-            userOp.paymasterAndData.length == 0
-                || specialPaymasters[address(bytes20(userOp.paymasterAndData[:20]))][msg.sender]
-        ) {
-            uint256 vgl = UserOperationLib.unpackVerificationGasLimit(userOp);
-            uint256 cgl = UserOperationLib.unpackCallGasLimit(userOp);
-            uint256 pvgl;
-            uint256 ppogl;
-            if (userOp.paymasterAndData.length > 0) {
-                // Can skip the EP length check here since it would have reverted there if it was invalid
-                (, pvgl, ppogl) = UserOperationLib.unpackPaymasterStaticFields(userOp.paymasterAndData);
+        if (userOp.paymasterAndData.length > 0) {
+            address paymaster = address(bytes20(userOp.paymasterAndData[:20]));
+            if (paymaster == address(0)) {
+                revert InvalidPaymaster();
+            } else if (specialPaymasters[paymaster][msg.sender]) {
+                _decreaseLimit(entityId, userOp);
             }
-            uint256 totalGas = userOp.preVerificationGas + vgl + cgl + pvgl + ppogl;
-            uint256 usage = totalGas * UserOperationLib.unpackMaxFeePerGas(userOp);
-
-            uint256 limit = limits[entityId][msg.sender];
-            if (usage > limit) {
-                revert ExceededNativeTokenLimit();
-            }
-            limits[entityId][msg.sender] = limit - usage;
+        } else {
+            _decreaseLimit(entityId, userOp);
         }
+
         return 0;
     }
 
@@ -162,5 +153,24 @@ contract NativeTokenLimitModule is ModuleBase, IExecutionHookModule, IValidation
     /// @inheritdoc ModuleBase
     function supportsInterface(bytes4 interfaceId) public view override(ModuleBase, IERC165) returns (bool) {
         return interfaceId == type(IExecutionHookModule).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    function _decreaseLimit(uint32 entityId, PackedUserOperation calldata userOp) internal {
+        uint256 vgl = UserOperationLib.unpackVerificationGasLimit(userOp);
+        uint256 cgl = UserOperationLib.unpackCallGasLimit(userOp);
+        uint256 pvgl;
+        uint256 ppogl;
+        if (userOp.paymasterAndData.length > 0) {
+            // Can skip the EP length check here since it would have reverted there if it was invalid
+            (, pvgl, ppogl) = UserOperationLib.unpackPaymasterStaticFields(userOp.paymasterAndData);
+        }
+        uint256 totalGas = userOp.preVerificationGas + vgl + cgl + pvgl + ppogl;
+        uint256 usage = totalGas * UserOperationLib.unpackMaxFeePerGas(userOp);
+
+        uint256 limit = limits[entityId][msg.sender];
+        if (usage > limit) {
+            revert ExceededNativeTokenLimit();
+        }
+        limits[entityId][msg.sender] = limit - usage;
     }
 }

--- a/src/modules/permissions/NativeTokenLimitModule.sol
+++ b/src/modules/permissions/NativeTokenLimitModule.sol
@@ -32,8 +32,7 @@ import {IERC165, ModuleBase} from "../ModuleBase.sol";
 /// @notice This module supports a total native token spend limit across User Operation gas and native transfers.
 /// - None of the functions are installed on the account. Account states are to be retrieved from this global
 ///   singleton directly.
-/// - This module only tracks native transfers for the 4 functions `execute`, `executeBatch`, `performCreate`,
-///   and `performCreate2.
+/// - This module only tracks native transfers for the 4 functions `execute`, `executeBatch`, `performCreate`.
 /// - By default, using a paymaster in a UO would cause the limit to not decrease. If an account uses a special
 ///   paymaster that converts non-native tokens in the account to pay for gas, this paymaster should be added to
 ///   the `specialPaymasters` list to enable the correct accounting of spend limits. When these paymasters are used

--- a/src/modules/permissions/PaymasterGuardModule.sol
+++ b/src/modules/permissions/PaymasterGuardModule.sol
@@ -36,12 +36,16 @@ contract PaymasterGuardModule is ModuleBase, IValidationHookModule {
     mapping(uint32 entityId => mapping(address account => address paymaster)) public paymasters;
 
     error BadPaymasterSpecified();
+    error InvalidPaymaster();
 
     /// @inheritdoc IModule
     /// @param data should be encoded with the entityId of the validation and the paymaster address that guards the
     /// validation
     function onInstall(bytes calldata data) external override {
         (uint32 entityId, address paymaster) = abi.decode(data, (uint32, address));
+        if (paymaster == address(0)) {
+            revert InvalidPaymaster();
+        }
         paymasters[entityId][msg.sender] = paymaster;
     }
 


### PR DESCRIPTION
Address ALC 2 where 0 paymaster address was not checked in modules.
* PaymasterGuardModule,  zero address paymaster is not allowed to be installed.
* NativeTokenLimitModule, zero address paymaster is not allowed `preUserOpValidationHook`. 