### PR TITLE
fix: [QS-01] revert on presence of validation hooks in deferred validation, and run validation-associated execution hooks

### DIFF
--- a/gas-snapshots/ModularAccount.json
+++ b/gas-snapshots/ModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "161528",
   "UserOp_UseSessionKey_Case1_Counter": "195233",
   "UserOp_UseSessionKey_Case1_Token": "226217",
-  "UserOp_deferredValidation": "260882"
+  "UserOp_deferredValidation": "260918"
 }

--- a/gas-snapshots/ModularAccount.json
+++ b/gas-snapshots/ModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "161528",
   "UserOp_UseSessionKey_Case1_Counter": "195233",
   "UserOp_UseSessionKey_Case1_Token": "226217",
-  "UserOp_deferredValidation": "257598"
+  "UserOp_deferredValidation": "260882"
 }

--- a/gas-snapshots/ModularAccount.json
+++ b/gas-snapshots/ModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "161528",
   "UserOp_UseSessionKey_Case1_Counter": "195233",
   "UserOp_UseSessionKey_Case1_Token": "226217",
-  "UserOp_deferredValidation": "260019"
+  "UserOp_deferredValidation": "257908"
 }

--- a/gas-snapshots/ModularAccount.json
+++ b/gas-snapshots/ModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "161528",
   "UserOp_UseSessionKey_Case1_Counter": "195233",
   "UserOp_UseSessionKey_Case1_Token": "226217",
-  "UserOp_deferredValidation": "260918"
+  "UserOp_deferredValidation": "260923"
 }

--- a/gas-snapshots/ModularAccount.json
+++ b/gas-snapshots/ModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "161528",
   "UserOp_UseSessionKey_Case1_Counter": "195233",
   "UserOp_UseSessionKey_Case1_Token": "226217",
-  "UserOp_deferredValidation": "260923"
+  "UserOp_deferredValidation": "260786"
 }

--- a/gas-snapshots/ModularAccount.json
+++ b/gas-snapshots/ModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "161528",
   "UserOp_UseSessionKey_Case1_Counter": "195233",
   "UserOp_UseSessionKey_Case1_Token": "226217",
-  "UserOp_deferredValidation": "260786"
+  "UserOp_deferredValidation": "260019"
 }

--- a/gas-snapshots/SemiModularAccount.json
+++ b/gas-snapshots/SemiModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "156770",
   "UserOp_UseSessionKey_Case1_Counter": "195473",
   "UserOp_UseSessionKey_Case1_Token": "226457",
-  "UserOp_deferredValidation": "257112"
+  "UserOp_deferredValidation": "257087"
 }

--- a/gas-snapshots/SemiModularAccount.json
+++ b/gas-snapshots/SemiModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "156770",
   "UserOp_UseSessionKey_Case1_Counter": "195473",
   "UserOp_UseSessionKey_Case1_Token": "226457",
-  "UserOp_deferredValidation": "256064"
+  "UserOp_deferredValidation": "253953"
 }

--- a/gas-snapshots/SemiModularAccount.json
+++ b/gas-snapshots/SemiModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "156770",
   "UserOp_UseSessionKey_Case1_Counter": "195473",
   "UserOp_UseSessionKey_Case1_Token": "226457",
-  "UserOp_deferredValidation": "256950"
+  "UserOp_deferredValidation": "256064"
 }

--- a/gas-snapshots/SemiModularAccount.json
+++ b/gas-snapshots/SemiModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "156770",
   "UserOp_UseSessionKey_Case1_Counter": "195473",
   "UserOp_UseSessionKey_Case1_Token": "226457",
-  "UserOp_deferredValidation": "257087"
+  "UserOp_deferredValidation": "256950"
 }

--- a/gas-snapshots/SemiModularAccount.json
+++ b/gas-snapshots/SemiModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "156770",
   "UserOp_UseSessionKey_Case1_Counter": "195473",
   "UserOp_UseSessionKey_Case1_Token": "226457",
-  "UserOp_deferredValidation": "257076"
+  "UserOp_deferredValidation": "257112"
 }

--- a/gas-snapshots/SemiModularAccount.json
+++ b/gas-snapshots/SemiModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "156770",
   "UserOp_UseSessionKey_Case1_Counter": "195473",
   "UserOp_UseSessionKey_Case1_Token": "226457",
-  "UserOp_deferredValidation": "253792"
+  "UserOp_deferredValidation": "257076"
 }

--- a/gas/modular-account/ModularAccount.gas.t.sol
+++ b/gas/modular-account/ModularAccount.gas.t.sol
@@ -279,12 +279,10 @@ contract ModularAccountGasTest is ModularAccountBenchmarkBase("ModularAccount") 
             account1, deferredInstallNonce, deferredInstallDeadline, newUOValidation, deferredValidationInstallCall
         );
 
-        bytes memory deferredValidationSig = _packFinalSignature(
-            _signRawHash(
-                vm,
-                owner1Key,
-                _getModuleReplaySafeHash(address(account1), address(singleSignerValidationModule), digest)
-            )
+        bytes memory deferredValidationSig = _signRawHash(
+            vm,
+            owner1Key,
+            _getModuleReplaySafeHash(address(account1), address(singleSignerValidationModule), digest)
         );
 
         userOp.signature = _encodeDeferredInstallUOSignature(

--- a/gas/modular-account/SemiModularAccount.gas.t.sol
+++ b/gas/modular-account/SemiModularAccount.gas.t.sol
@@ -273,7 +273,7 @@ contract ModularAccountGasTest is ModularAccountBenchmarkBase("SemiModularAccoun
             account1, deferredInstallNonce, deferredInstallDeadline, newUOValidation, deferredValidationInstallCall
         );
 
-        bytes memory deferredValidationSig = _packFinalSignature(_signRawHash(vm, owner1Key, digest));
+        bytes memory deferredValidationSig = _signRawHash(vm, owner1Key, digest);
 
         userOp.signature = _encodeDeferredInstallUOSignature(
             ValidationConfigLib.moduleEntity(newUOValidation),

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -104,6 +104,7 @@ abstract contract ModularAccountBase is
     error UnexpectedAggregator(ModuleEntity validationFunction, address aggregator);
     error UnrecognizedFunction(bytes4 selector);
     error ValidationFunctionMissing(bytes4 selector);
+    error OuterValidationHasValidationHooks();
 
     // Wraps execution of a native function with runtime validation and hooks
     // Used for upgradeTo, upgradeToAndCall, execute, executeBatch, installExecution, uninstallExecution,
@@ -415,11 +416,18 @@ abstract contract ModularAccountBase is
         if (hasDeferredAction) {
             // Use outer validation to validate the UO, and the inner validation as 1271 validation for the
             // deferred action.
+            // Because this bypasses UO validation hooks, we require that the validation used does not include any
+            // validation hooks.
+            if (!getAccountStorage().validationStorage[validationFunction].validationHooks.isEmpty()) {
+                revert OuterValidationHasValidationHooks();
+            }
+
+            // Use outer validation as a 1271 validation, then use the inner validation to validate the UO.
 
             // Get the length of the deferred action data.
             uint256 encodedDataLength = uint32(bytes4(userOp.signature[25:29]));
 
-            // Load the pointer to the abi-encoded data.
+            // Load the pointer to the encoded data.
             bytes calldata encodedData = userOp.signature[29:29 + encodedDataLength];
 
             // Get the deferred action signature length.
@@ -443,8 +451,15 @@ abstract contract ModularAccountBase is
             // Update the validation data with the deadline.
             validationData = uint256(deadline) << 160;
 
+            // Run the validation associated execution hooks, this is extracted in a function for stack management.
+            DensePostHookData postHookData =
+                _runValidationAssociatedExecHooks(validationFunction, encodedData[63:]);
+
             // Perform the deferred action's self call on the account.
             ExecutionLib.callBubbleOnRevertTransient(address(this), 0, encodedData[63:]);
+
+            // Do the cached post hooks
+            ExecutionLib.doCachedPostHooks(postHookData);
         } else {
             userOpSignature = userOp.signature[25:];
         }
@@ -506,7 +521,7 @@ abstract contract ModularAccountBase is
         emit DeferredActionNonceInvalidated(nonce);
 
         // Compute the typed data hash to verify the signature over
-        bytes32 typedDataHash = _computeDeferredValidationInstallTypedDataHash(
+        bytes32 typedDataHash = _computeDeferredActionTypedDataHash(
             encodedData[63:], // The encoded call without the nonce, deadline, and validation function
             nonce,
             deadline,
@@ -709,6 +724,21 @@ abstract contract ModularAccountBase is
         ExecutionLib.convertToValidationBuffer(callBuffer);
 
         return ExecutionLib.invokeUserOpCallBuffer(callBuffer, userOpValidationFunction, signatureSegment);
+    }
+
+    function _runValidationAssociatedExecHooks(ModuleEntity validationFunction, bytes calldata callData)
+        internal
+        returns (DensePostHookData)
+    {
+        HookConfig[] memory validationAssocExecHooks =
+            MemManagementLib.loadExecHooks(getAccountStorage().validationStorage[validationFunction]);
+
+        PHCallBuffer callBuffer;
+        if (validationAssocExecHooks.length > 0) {
+            callBuffer = ExecutionLib.allocatePreExecHookCallBuffer(callData);
+        }
+
+        return ExecutionLib.doPreHooks(validationAssocExecHooks, callBuffer);
     }
 
     function _execRuntimeValidation(
@@ -1023,7 +1053,7 @@ abstract contract ModularAccountBase is
         return getAccountStorage().validationStorage[validationFunction].selectors.contains(toSetValue(selector));
     }
 
-    function _computeDeferredValidationInstallTypedDataHash(
+    function _computeDeferredActionTypedDataHash(
         bytes calldata selfCall,
         uint256 nonce,
         uint48 deadline,

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -414,7 +414,7 @@ abstract contract ModularAccountBase is
         ///      [(33 + deferredActionSigLength + encodedDataLength):] : bytes, userOpSignature. This is the
         ///         signature passed to the inner validation.
         if (hasDeferredAction) {
-            // Use outer inner validation as a 1271 validation for the deferred action, then use the outer
+            // Use inner validation as a 1271 validation for the deferred action, then use the outer
             // validation to validate the UO.
 
             // Get the length of the deferred action data.

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -445,7 +445,7 @@ abstract contract ModularAccountBase is
             // validation memory.
             MemSnapshot memSnapshot = MemManagementLib.freezeFMP();
 
-            uint48 deadline = _validateDeferredAction(uoValidation, encodedData, deferredActionSig);
+            uint48 deadline = _handleDeferredAction(uoValidation, encodedData, deferredActionSig);
 
             // Restore the free memory pointer.
             MemManagementLib.restoreFMP(memSnapshot);
@@ -482,7 +482,7 @@ abstract contract ModularAccountBase is
     }
 
     /// @return The deadline of the deferred action
-    function _validateDeferredAction(
+    function _handleDeferredAction(
         bytes25 userOpValidationFunction,
         bytes calldata encodedData,
         bytes calldata sig
@@ -508,13 +508,10 @@ abstract contract ModularAccountBase is
             isGlobalSigValidation ? ValidationCheckingType.GLOBAL : ValidationCheckingType.SELECTOR
         );
 
-        // Compute the typed data hash to verify the signature over, and fetch the deadline
-        (bytes32 typedDataHash, uint48 deadline) =
-            _handleSelfCall712DataAndNonce(encodedData, userOpValidationFunction);
-
-        if (_isValidSignature(defActionValidationModuleEntity, typedDataHash, sig) != _1271_MAGIC_VALUE) {
-            revert DeferredActionSignatureInvalid();
-        }
+        // Handle the signature validation
+        uint48 deadline = _validateDeferredActionSignature(
+            encodedData, sig, userOpValidationFunction, defActionValidationModuleEntity
+        );
 
         // Run the validation associated execution hooks, allocating a call buffer as needed.
         HookConfig[] memory validationAssocExecHooks =
@@ -732,13 +729,12 @@ abstract contract ModularAccountBase is
         ExecutionLib.invokeRuntimeCallBufferValidation(callBuffer, runtimeValidationFunction, authorization);
     }
 
-    function _handleSelfCall712DataAndNonce(
+    function _validateDeferredActionSignature(
         bytes calldata encodedData,
-        // bytes calldata selfCall,
-        // uint256 nonce,
-        // uint48 deadline,
-        bytes25 validationFunction
-    ) internal returns (bytes32, uint48) {
+        bytes calldata signature,
+        bytes25 userOpValidationFunction,
+        ModuleEntity deferredSigValidationModuleEntity
+    ) internal returns (uint48) {
         uint256 nonce = uint256(bytes32(encodedData[:32]));
         uint48 deadline = uint48(bytes6(encodedData[32:38]));
 
@@ -755,7 +751,7 @@ abstract contract ModularAccountBase is
         // The following is equivalent to:
         // keccak256(
         //     abi.encode(
-        //         _INSTALL_VALIDATION_TYPEHASH,
+        //         _DEFERRED_ACTION_TYPEHASH,
         //         nonce,
         //         deadline,
         //         validationFunction,
@@ -768,38 +764,58 @@ abstract contract ModularAccountBase is
         // Fetch the self-call from the encoded data.
         bytes calldata selfCall = encodedData[63:];
 
-        // This will hold the EIP712 structHash.
-        bytes32 structHash;
+        // Compute the typed data hash.
+        bytes32 typedDataHash;
+        {
+            bytes32 structHash;
 
-        assembly ("memory-safe") {
-            // Get the hash of the dynamic-length encoded install call
-            let fmp := mload(0x40)
-            calldatacopy(fmp, selfCall.offset, selfCall.length)
-            let selfCallHash := keccak256(fmp, selfCall.length)
+            assembly ("memory-safe") {
+                // Get the hash of the dynamic-length encoded install call
+                let fmp := mload(0x40)
+                calldatacopy(fmp, selfCall.offset, selfCall.length)
+                let selfCallHash := keccak256(fmp, selfCall.length)
 
-            // Compute the struct hash
-            let ptr := fmp
-            mstore(ptr, _DEFERRED_ACTION_TYPEHASH)
-            ptr := add(ptr, 0x20)
-            mstore(ptr, nonce)
-            ptr := add(ptr, 0x20)
-            // Clear the upper bits of the deadline, in case the caller didn't.
-            mstore(ptr, and(deadline, 0xffffffffffff))
-            ptr := add(ptr, 0x20)
-            // Clear the lower bits of the validation function, in case the caller didn't.
-            mstore(
-                ptr, and(validationFunction, 0xffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000)
-            )
-            ptr := add(ptr, 0x20)
-            mstore(ptr, selfCallHash)
+                // Compute the struct hash
+                let ptr := fmp
+                mstore(ptr, _DEFERRED_ACTION_TYPEHASH)
+                ptr := add(ptr, 0x20)
+                mstore(ptr, nonce)
+                ptr := add(ptr, 0x20)
+                // Clear the upper bits of the deadline, in case the caller didn't.
+                mstore(ptr, and(deadline, 0xffffffffffff))
+                ptr := add(ptr, 0x20)
+                // Clear the lower bits of the validation function, in case the caller didn't.
+                mstore(
+                    ptr,
+                    and(
+                        userOpValidationFunction,
+                        0xffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000
+                    )
+                )
+                ptr := add(ptr, 0x20)
+                mstore(ptr, selfCallHash)
 
-            // Compute the struct hash
-            structHash := keccak256(fmp, 0xa0)
+                // Compute the struct hash
+                structHash := keccak256(fmp, 0xa0)
+            }
+
+            typedDataHash = MessageHashUtils.toTypedDataHash(_domainSeparator(), structHash);
         }
 
-        bytes32 typedDataHash = MessageHashUtils.toTypedDataHash(_domainSeparator(), structHash);
+        // Validate the 1271 signature.
+        SigCallBuffer sigCallBuffer;
+        if (!_validationIsNative(deferredSigValidationModuleEntity)) {
+            sigCallBuffer = ExecutionLib.allocateSigCallBuffer(typedDataHash, signature);
+        }
 
-        return (typedDataHash, deadline);
+        if (
+            _exec1271Validation(sigCallBuffer, typedDataHash, deferredSigValidationModuleEntity, signature)
+                != _1271_MAGIC_VALUE
+        ) {
+            revert DeferredActionSignatureInvalid();
+        }
+
+        return deadline;
     }
 
     function _isValidSignature(ModuleEntity sigValidation, bytes32 hash, bytes calldata signature)

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -414,7 +414,8 @@ abstract contract ModularAccountBase is
         ///      [(33 + deferredActionSigLength + encodedDataLength):] : bytes, userOpSignature. This is the
         ///         signature passed to the inner validation.
         if (hasDeferredAction) {
-            // Use outer validation as a 1271 validation, then use the inner validation to validate the UO.
+            // Use outer inner validation as a 1271 validation for the deferred action, then use the outer
+            // validation to validate the UO.
 
             // Get the length of the deferred action data.
             uint256 encodedDataLength = uint32(bytes4(userOp.signature[25:29]));
@@ -439,16 +440,18 @@ abstract contract ModularAccountBase is
             // Note that while the declared type of the UO validation is `ValidationConfig`, the flags are
             // interpretted as validation selection flags, not validation installation flags.
             bytes25 uoValidation = bytes25(userOp.signature[:25]);
-            (uint48 deadline, DensePostHookData postHookData) =
-                _validateDeferredActionAndSetNonce(uoValidation, encodedData, deferredActionSig);
+
+            // Freeze the free-memory pointer, since we won't need to use anything from the deferred action
+            // validation memory.
+            MemSnapshot memSnapshot = MemManagementLib.freezeFMP();
+
+            uint48 deadline = _validateDeferredAction(uoValidation, encodedData, deferredActionSig);
+
+            // Restore the free memory pointer.
+            MemManagementLib.restoreFMP(memSnapshot);
+
             // Update the validation data with the deadline.
             validationData = uint256(deadline) << 160;
-
-            // Perform the deferred action's self call on the account.
-            ExecutionLib.callBubbleOnRevertTransient(address(this), 0, encodedData[63:]);
-
-            // Do the cached post hooks
-            ExecutionLib.doCachedPostHooks(postHookData);
         } else {
             userOpSignature = userOp.signature[25:];
         }
@@ -479,12 +482,11 @@ abstract contract ModularAccountBase is
     }
 
     /// @return The deadline of the deferred action
-    function _validateDeferredActionAndSetNonce(
+    function _validateDeferredAction(
         bytes25 userOpValidationFunction,
         bytes calldata encodedData,
         bytes calldata sig
-    ) internal returns (uint48, DensePostHookData) {
-        // Decode stack vars for the deadline and nonce.
+    ) internal returns (uint48) {
         // The deadline, nonce, inner validation, and deferred call selector are all at fixed positions in the
         // encodedData.
 
@@ -507,20 +509,31 @@ abstract contract ModularAccountBase is
         );
 
         // Compute the typed data hash to verify the signature over, and fetch the deadline
-        (bytes32 typedDataHash, uint48 deadline) = _checkAndCompute712Data(encodedData, userOpValidationFunction);
+        (bytes32 typedDataHash, uint48 deadline) =
+            _handleSelfCall712DataAndNonce(encodedData, userOpValidationFunction);
 
-        // Clear the memory after performing signature validation
-        MemSnapshot memSnapshot = MemManagementLib.freezeFMP();
         if (_isValidSignature(defActionValidationModuleEntity, typedDataHash, sig) != _1271_MAGIC_VALUE) {
             revert DeferredActionSignatureInvalid();
         }
-        MemManagementLib.restoreFMP(memSnapshot);
 
-        // Run the validation associated execution hooks, this is extracted in a function for stack management.
-        DensePostHookData postHookData =
-            _runValidationAssociatedExecHooks(defActionValidationModuleEntity, encodedData[63:]);
+        // Run the validation associated execution hooks, allocating a call buffer as needed.
+        HookConfig[] memory validationAssocExecHooks =
+            MemManagementLib.loadExecHooks(getAccountStorage().validationStorage[defActionValidationModuleEntity]);
 
-        return (deadline, postHookData);
+        PHCallBuffer callBuffer;
+        if (validationAssocExecHooks.length > 0) {
+            callBuffer = ExecutionLib.allocatePreExecHookCallBuffer(encodedData[63:]);
+        }
+
+        DensePostHookData postHookData = ExecutionLib.doPreHooks(validationAssocExecHooks, callBuffer);
+
+        // Perform the deferred action's self call on the account.
+        ExecutionLib.callBubbleOnRevertTransient(address(this), 0, encodedData[63:]);
+
+        // Do the cached post hooks
+        ExecutionLib.doCachedPostHooks(postHookData);
+
+        return deadline;
     }
 
     // To support gas estimation, we don't fail early when the failure is caused by a signature failure
@@ -711,21 +724,6 @@ abstract contract ModularAccountBase is
         return ExecutionLib.invokeUserOpCallBuffer(callBuffer, userOpValidationFunction, signatureSegment);
     }
 
-    function _runValidationAssociatedExecHooks(ModuleEntity validationFunction, bytes calldata callData)
-        internal
-        returns (DensePostHookData)
-    {
-        HookConfig[] memory validationAssocExecHooks =
-            MemManagementLib.loadExecHooks(getAccountStorage().validationStorage[validationFunction]);
-
-        PHCallBuffer callBuffer;
-        if (validationAssocExecHooks.length > 0) {
-            callBuffer = ExecutionLib.allocatePreExecHookCallBuffer(callData);
-        }
-
-        return ExecutionLib.doPreHooks(validationAssocExecHooks, callBuffer);
-    }
-
     function _execRuntimeValidation(
         ModuleEntity runtimeValidationFunction,
         RTCallBuffer callBuffer,
@@ -734,7 +732,7 @@ abstract contract ModularAccountBase is
         ExecutionLib.invokeRuntimeCallBufferValidation(callBuffer, runtimeValidationFunction, authorization);
     }
 
-    function _checkAndCompute712Data(
+    function _handleSelfCall712DataAndNonce(
         bytes calldata encodedData,
         // bytes calldata selfCall,
         // uint256 nonce,
@@ -753,8 +751,6 @@ abstract contract ModularAccountBase is
         getAccountStorage().deferredActionNonceUsed[nonce] = true;
         emit DeferredActionNonceInvalidated(nonce);
 
-        // bytes32 result;
-
         // Compute the hash without permanently allocating memory for each step.
         // The following is equivalent to:
         // keccak256(
@@ -768,7 +764,11 @@ abstract contract ModularAccountBase is
         // )
 
         // Note that a zero deadline translates to "no deadline"
+
+        // Fetch the self-call from the encoded data.
         bytes calldata selfCall = encodedData[63:];
+
+        // This will hold the EIP712 structHash.
         bytes32 structHash;
 
         assembly ("memory-safe") {

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -104,7 +104,7 @@ abstract contract ModularAccountBase is
     error UnexpectedAggregator(ModuleEntity validationFunction, address aggregator);
     error UnrecognizedFunction(bytes4 selector);
     error ValidationFunctionMissing(bytes4 selector);
-    error OuterValidationHasValidationHooks();
+    error DeferredValidationHasValidationHooks();
 
     // Wraps execution of a native function with runtime validation and hooks
     // Used for upgradeTo, upgradeToAndCall, execute, executeBatch, installExecution, uninstallExecution,
@@ -414,14 +414,6 @@ abstract contract ModularAccountBase is
         ///      [(33 + deferredActionSigLength + encodedDataLength):] : bytes, userOpSignature. This is the
         ///         signature passed to the inner validation.
         if (hasDeferredAction) {
-            // Use outer validation to validate the UO, and the inner validation as 1271 validation for the
-            // deferred action.
-            // Because this bypasses UO validation hooks, we require that the validation used does not include any
-            // validation hooks.
-            if (!getAccountStorage().validationStorage[validationFunction].validationHooks.isEmpty()) {
-                revert OuterValidationHasValidationHooks();
-            }
-
             // Use outer validation as a 1271 validation, then use the inner validation to validate the UO.
 
             // Get the length of the deferred action data.
@@ -447,13 +439,10 @@ abstract contract ModularAccountBase is
             // Note that while the declared type of the UO validation is `ValidationConfig`, the flags are
             // interpretted as validation selection flags, not validation installation flags.
             bytes25 uoValidation = bytes25(userOp.signature[:25]);
-            uint48 deadline = _validateDeferredActionAndSetNonce(uoValidation, encodedData, deferredActionSig);
+            (uint48 deadline, DensePostHookData postHookData) =
+                _validateDeferredActionAndSetNonce(uoValidation, encodedData, deferredActionSig);
             // Update the validation data with the deadline.
             validationData = uint256(deadline) << 160;
-
-            // Run the validation associated execution hooks, this is extracted in a function for stack management.
-            DensePostHookData postHookData =
-                _runValidationAssociatedExecHooks(validationFunction, encodedData[63:]);
 
             // Perform the deferred action's self call on the account.
             ExecutionLib.callBubbleOnRevertTransient(address(this), 0, encodedData[63:]);
@@ -494,7 +483,7 @@ abstract contract ModularAccountBase is
         bytes25 userOpValidationFunction,
         bytes calldata encodedData,
         bytes calldata sig
-    ) internal returns (uint48) {
+    ) internal returns (uint48, DensePostHookData) {
         // Decode stack vars for the deadline and nonce.
         // The deadline, nonce, inner validation, and deferred call selector are all at fixed positions in the
         // encodedData.
@@ -504,10 +493,18 @@ abstract contract ModularAccountBase is
         ValidationConfig defActionSigValidation = ValidationConfig.wrap(bytes25(encodedData[38:63]));
         bool isGlobalSigValidation = defActionSigValidation.isGlobal();
 
+        ModuleEntity defActionValidationModuleEntity = defActionSigValidation.moduleEntity();
+
+        // Because this bypasses UO validation hooks, we require that the validation used does not include any
+        // validation hooks.
+        if (!getAccountStorage().validationStorage[defActionValidationModuleEntity].validationHooks.isEmpty()) {
+            revert DeferredValidationHasValidationHooks();
+        }
+
         // Check if the outer validation applies to the function call
         _checkIfValidationAppliesCallData(
             encodedData[63:],
-            defActionSigValidation.moduleEntity(),
+            defActionValidationModuleEntity,
             isGlobalSigValidation ? ValidationCheckingType.GLOBAL : ValidationCheckingType.SELECTOR
         );
 
@@ -530,12 +527,16 @@ abstract contract ModularAccountBase is
 
         // Clear the memory after performing signature validation
         MemSnapshot memSnapshot = MemManagementLib.freezeFMP();
-        if (_isValidSignature(defActionSigValidation.moduleEntity(), typedDataHash, sig) != _1271_MAGIC_VALUE) {
+        if (_isValidSignature(defActionValidationModuleEntity, typedDataHash, sig) != _1271_MAGIC_VALUE) {
             revert DeferredActionSignatureInvalid();
         }
         MemManagementLib.restoreFMP(memSnapshot);
 
-        return deadline;
+        // Run the validation associated execution hooks, this is extracted in a function for stack management.
+        DensePostHookData postHookData =
+            _runValidationAssociatedExecHooks(defActionValidationModuleEntity, encodedData[63:]);
+
+        return (deadline, postHookData);
     }
 
     // To support gas estimation, we don't fail early when the failure is caused by a signature failure

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -497,7 +497,7 @@ abstract contract ModularAccountBase is
 
         // Because this bypasses UO validation hooks, we require that the validation used does not include any
         // validation hooks.
-        if (!getAccountStorage().validationStorage[defActionValidationModuleEntity].validationHooks.isEmpty()) {
+        if (getAccountStorage().validationStorage[defActionValidationModuleEntity].validationHookCount != 0) {
             revert DeferredValidationHasValidationHooks();
         }
 

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -487,8 +487,6 @@ abstract contract ModularAccountBase is
         // Decode stack vars for the deadline and nonce.
         // The deadline, nonce, inner validation, and deferred call selector are all at fixed positions in the
         // encodedData.
-        uint256 nonce = uint256(bytes32(encodedData[:32]));
-        uint48 deadline = uint48(bytes6(encodedData[32:38]));
 
         ValidationConfig defActionSigValidation = ValidationConfig.wrap(bytes25(encodedData[38:63]));
         bool isGlobalSigValidation = defActionSigValidation.isGlobal();
@@ -508,22 +506,8 @@ abstract contract ModularAccountBase is
             isGlobalSigValidation ? ValidationCheckingType.GLOBAL : ValidationCheckingType.SELECTOR
         );
 
-        // Check that the passed nonce isn't already invalidated.
-        if (getAccountStorage().deferredActionNonceUsed[nonce]) {
-            revert DeferredActionNonceInvalid();
-        }
-
-        // Invalidate the nonce.
-        getAccountStorage().deferredActionNonceUsed[nonce] = true;
-        emit DeferredActionNonceInvalidated(nonce);
-
-        // Compute the typed data hash to verify the signature over
-        bytes32 typedDataHash = _computeDeferredActionTypedDataHash(
-            encodedData[63:], // The encoded call without the nonce, deadline, and validation function
-            nonce,
-            deadline,
-            userOpValidationFunction
-        );
+        // Compute the typed data hash to verify the signature over, and fetch the deadline
+        (bytes32 typedDataHash, uint48 deadline) = _checkAndCompute712Data(encodedData, userOpValidationFunction);
 
         // Clear the memory after performing signature validation
         MemSnapshot memSnapshot = MemManagementLib.freezeFMP();
@@ -748,6 +732,74 @@ abstract contract ModularAccountBase is
         bytes calldata authorization
     ) internal virtual {
         ExecutionLib.invokeRuntimeCallBufferValidation(callBuffer, runtimeValidationFunction, authorization);
+    }
+
+    function _checkAndCompute712Data(
+        bytes calldata encodedData,
+        // bytes calldata selfCall,
+        // uint256 nonce,
+        // uint48 deadline,
+        bytes25 validationFunction
+    ) internal returns (bytes32, uint48) {
+        uint256 nonce = uint256(bytes32(encodedData[:32]));
+        uint48 deadline = uint48(bytes6(encodedData[32:38]));
+
+        // Check that the passed nonce isn't already invalidated.
+        if (getAccountStorage().deferredActionNonceUsed[nonce]) {
+            revert DeferredActionNonceInvalid();
+        }
+
+        // Invalidate the nonce.
+        getAccountStorage().deferredActionNonceUsed[nonce] = true;
+        emit DeferredActionNonceInvalidated(nonce);
+
+        // bytes32 result;
+
+        // Compute the hash without permanently allocating memory for each step.
+        // The following is equivalent to:
+        // keccak256(
+        //     abi.encode(
+        //         _INSTALL_VALIDATION_TYPEHASH,
+        //         nonce,
+        //         deadline,
+        //         validationFunction,
+        //         keccak256(selfCall)
+        //     )
+        // )
+
+        // Note that a zero deadline translates to "no deadline"
+        bytes calldata selfCall = encodedData[63:];
+        bytes32 structHash;
+
+        assembly ("memory-safe") {
+            // Get the hash of the dynamic-length encoded install call
+            let fmp := mload(0x40)
+            calldatacopy(fmp, selfCall.offset, selfCall.length)
+            let selfCallHash := keccak256(fmp, selfCall.length)
+
+            // Compute the struct hash
+            let ptr := fmp
+            mstore(ptr, _DEFERRED_ACTION_TYPEHASH)
+            ptr := add(ptr, 0x20)
+            mstore(ptr, nonce)
+            ptr := add(ptr, 0x20)
+            // Clear the upper bits of the deadline, in case the caller didn't.
+            mstore(ptr, and(deadline, 0xffffffffffff))
+            ptr := add(ptr, 0x20)
+            // Clear the lower bits of the validation function, in case the caller didn't.
+            mstore(
+                ptr, and(validationFunction, 0xffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000)
+            )
+            ptr := add(ptr, 0x20)
+            mstore(ptr, selfCallHash)
+
+            // Compute the struct hash
+            structHash := keccak256(fmp, 0xa0)
+        }
+
+        bytes32 typedDataHash = MessageHashUtils.toTypedDataHash(_domainSeparator(), structHash);
+
+        return (typedDataHash, deadline);
     }
 
     function _isValidSignature(ModuleEntity sigValidation, bytes32 hash, bytes calldata signature)
@@ -1052,61 +1104,6 @@ abstract contract ModularAccountBase is
         returns (bool)
     {
         return getAccountStorage().validationStorage[validationFunction].selectors.contains(toSetValue(selector));
-    }
-
-    function _computeDeferredActionTypedDataHash(
-        bytes calldata selfCall,
-        uint256 nonce,
-        uint48 deadline,
-        bytes25 validationFunction
-    ) internal view returns (bytes32) {
-        // bytes32 result;
-
-        // Compute the hash without permanently allocating memory for each step.
-        // The following is equivalent to:
-        // keccak256(
-        //     abi.encode(
-        //         _INSTALL_VALIDATION_TYPEHASH,
-        //         nonce,
-        //         deadline,
-        //         validationFunction,
-        //         keccak256(selfCall)
-        //     )
-        // )
-
-        // Note that a zero deadline translates to "no deadline"
-
-        bytes32 structHash;
-
-        assembly ("memory-safe") {
-            // Get the hash of the dynamic-length encoded install call
-            let fmp := mload(0x40)
-            calldatacopy(fmp, selfCall.offset, selfCall.length)
-            let selfCallHash := keccak256(fmp, selfCall.length)
-
-            // Compute the struct hash
-            let ptr := fmp
-            mstore(ptr, _DEFERRED_ACTION_TYPEHASH)
-            ptr := add(ptr, 0x20)
-            mstore(ptr, nonce)
-            ptr := add(ptr, 0x20)
-            // Clear the upper bits of the deadline, in case the caller didn't.
-            mstore(ptr, and(deadline, 0xffffffffffff))
-            ptr := add(ptr, 0x20)
-            // Clear the lower bits of the validation function, in case the caller didn't.
-            mstore(
-                ptr, and(validationFunction, 0xffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000)
-            )
-            ptr := add(ptr, 0x20)
-            mstore(ptr, selfCallHash)
-
-            // Compute the struct hash
-            structHash := keccak256(fmp, 0xa0)
-        }
-
-        bytes32 typedDataHash = MessageHashUtils.toTypedDataHash(_domainSeparator(), structHash);
-
-        return typedDataHash;
     }
 
     function _domainSeparator() internal view returns (bytes32) {

--- a/test/account/DeferredValidation.t.sol
+++ b/test/account/DeferredValidation.t.sol
@@ -31,6 +31,7 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 
 import {ModularAccount} from "../../src/account/ModularAccount.sol";
 import {ModularAccountBase} from "../../src/account/ModularAccountBase.sol";
+import {MockCountModule} from "../mocks/modules/MockCountModule.sol";
 import {AccountTestBase} from "../utils/AccountTestBase.sol";
 
 contract DeferredValidationTest is AccountTestBase {
@@ -377,6 +378,59 @@ contract DeferredValidationTest is AccountTestBase {
         );
 
         _sendOp(userOp, "");
+    }
+
+    function test_deferredValidation_deployedWithValAssocExecHooks() external withSMATest {
+        MockCountModule hookModule = new MockCountModule();
+
+        // Install a validation-associated execution hook to the outer validation.
+        bytes[] memory hooks = new bytes[](1);
+        hooks[0] = abi.encodePacked(
+            HookConfigLib.packExecHook({_module: address(hookModule), _entityId: 0, _hasPre: true, _hasPost: true}),
+            "" // onInstall data
+        );
+        vm.prank(address(entryPoint));
+        account1.installValidation(
+            ValidationConfigLib.pack(_signerValidation, true, true, true), new bytes4[](0), "", hooks
+        );
+
+        uint256 nonce = entryPoint.getNonce(address(account1), 0);
+
+        PackedUserOperation memory userOp = PackedUserOperation({
+            sender: address(account1),
+            nonce: nonce,
+            initCode: hex"",
+            callData: _encodedCall,
+            accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
+            preVerificationGas: 0,
+            gasFees: _encodeGas(1, 1),
+            paymasterAndData: hex"",
+            signature: ""
+        });
+
+        bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
+        (uint8 v, bytes32 r, bytes32 s) =
+            vm.sign(_newSignerKey, MessageHashUtils.toEthSignedMessageHash(userOpHash));
+        bytes memory uoSig = _packFinalSignature(abi.encodePacked(EOA_TYPE_SIGNATURE, r, s, v));
+
+        uint256 deferredInstallNonce = 0;
+        uint48 deferredInstallDeadline = 0;
+
+        userOp.signature = _buildFullDeferredInstallSig(
+            deferredInstallNonce,
+            deferredInstallDeadline,
+            _deferredValidationInstallCall,
+            _newUOValidation,
+            account1,
+            owner1Key,
+            uoSig
+        );
+
+        _sendOp(userOp, "");
+
+        // Ensure the pre and post-exec hook ran successfully.
+        assertEq(hookModule.preExecutionHookRunCount(), 1);
+        assertEq(hookModule.postExecutionHookRunCount(), 1);
     }
 
     function test_deferredValidation_initCode() external withSMATest {

--- a/test/account/DeferredValidation.t.sol
+++ b/test/account/DeferredValidation.t.sol
@@ -22,6 +22,7 @@ import {
     ModuleEntity,
     ValidationConfig
 } from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "@erc6900/reference-implementation/libraries/ValidationConfigLib.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
@@ -284,6 +285,59 @@ contract DeferredValidationTest is AccountTestBase {
         bytes memory expectedRevertData =
             abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA24 signature error");
 
+        _sendOp(userOp, expectedRevertData);
+    }
+
+    function test_fail_deferredValidation_withValidationHooks() external withSMATest {
+        // Install a validation hook to the outer validation.
+        bytes[] memory hooks = new bytes[](1);
+        hooks[0] = abi.encodePacked(
+            HookConfigLib.packValidationHook({_module: address(12), _entityId: 0}),
+            "" // onInstall data
+        );
+        vm.prank(address(entryPoint));
+        account1.installValidation(
+            ValidationConfigLib.pack(_signerValidation, true, true, true), new bytes4[](0), "", hooks
+        );
+
+        uint256 nonce = entryPoint.getNonce(address(account1), 0);
+
+        PackedUserOperation memory userOp = PackedUserOperation({
+            sender: address(account1),
+            nonce: nonce,
+            initCode: hex"",
+            callData: _encodedCall,
+            accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
+            preVerificationGas: 0,
+            gasFees: _encodeGas(1, 1),
+            paymasterAndData: hex"",
+            signature: ""
+        });
+
+        bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
+        (uint8 v, bytes32 r, bytes32 s) =
+            vm.sign(_newSignerKey, MessageHashUtils.toEthSignedMessageHash(userOpHash));
+        bytes memory uoSig = _packFinalSignature(abi.encodePacked(EOA_TYPE_SIGNATURE, r, s, v));
+
+        uint256 deferredInstallNonce = 0;
+        uint48 deferredInstallDeadline = 0;
+
+        userOp.signature = _buildFullDeferredInstallSig(
+            deferredInstallNonce,
+            deferredInstallDeadline,
+            _deferredValidationInstallCall,
+            _newUOValidation,
+            account1,
+            owner1Key,
+            uoSig
+        );
+
+        bytes memory expectedRevertData = abi.encodeWithSelector(
+            IEntryPoint.FailedOpWithRevert.selector,
+            0,
+            "AA23 reverted",
+            abi.encodeWithSelector(ModularAccountBase.OuterValidationHasValidationHooks.selector)
+        );
         _sendOp(userOp, expectedRevertData);
     }
 

--- a/test/account/DeferredValidation.t.sol
+++ b/test/account/DeferredValidation.t.sol
@@ -380,7 +380,7 @@ contract DeferredValidationTest is AccountTestBase {
         _sendOp(userOp, "");
     }
 
-    function test_deferredValidation_deployedWithValAssocExecHooks() external withSMATest {
+    function test_deferredValidation_deployedWithValidationAssociatedExecHooks() external withSMATest {
         MockCountModule hookModule = new MockCountModule();
 
         // Install a validation-associated execution hook to the outer validation.

--- a/test/account/DeferredValidation.t.sol
+++ b/test/account/DeferredValidation.t.sol
@@ -337,7 +337,7 @@ contract DeferredValidationTest is AccountTestBase {
             IEntryPoint.FailedOpWithRevert.selector,
             0,
             "AA23 reverted",
-            abi.encodeWithSelector(ModularAccountBase.OuterValidationHasValidationHooks.selector)
+            abi.encodeWithSelector(ModularAccountBase.DeferredValidationHasValidationHooks.selector)
         );
         _sendOp(userOp, expectedRevertData);
     }

--- a/test/mocks/modules/MockCountModule.sol
+++ b/test/mocks/modules/MockCountModule.sol
@@ -38,7 +38,7 @@ contract MockCountModule is ModuleBase, IExecutionHookModule, IValidationHookMod
     function postExecutionHook(uint32, bytes calldata preExecHookData) external override {
         require(
             abi.decode(preExecHookData, (bytes32)) == keccak256(hex"04546b"),
-            "mock direct call post execution hook failed"
+            "mockCountModule post execution hook failed"
         );
         postExecutionHookRunCount++;
     }

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -323,7 +323,7 @@ abstract contract AccountTestBase is OptimizedTest, ModuleSignatureUtils {
                     _getModuleReplaySafeHash(address(account), address(singleSignerValidationModule), digest);
             }
 
-            deferredValidationSig = _packFinalSignature(_signRawHash(vm, signingKey, replaySafeHash));
+            deferredValidationSig = _signRawHash(vm, signingKey, replaySafeHash);
 
             deferredValidationDatas = _packDeferredInstallData(
                 deferredInstallNonce,


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Currently, it's possible to skip userOp validation hooks if the validation function being used is also a signature validation through deferred installation. Furthermore, we're not running userOp validation-associated execution hooks, when we could be.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

Revert if the validation being used includes validation hooks, and run the validation-associated pre and post hooks tied to that validation.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->