### PR TITLE
feat: add 7702 compatible semi modular account

### DIFF
--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -371,6 +371,7 @@ abstract contract ModularAccountBase is
     function upgradeToAndCall(address newImplementation, bytes calldata data)
         public
         payable
+        virtual
         override
         onlyProxy
         wrapNativeFunction

--- a/src/account/SemiModularAccount7702.sol
+++ b/src/account/SemiModularAccount7702.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
+
+import {SemiModularAccountBase} from "./SemiModularAccountBase.sol";
+
+/// @title Semi-Modular Account for EIP-7702 EOAs
+/// @author Alchemy
+/// @notice An implementation of a semi-modular account which reads the signer as the address(this).
+/// @dev Inherits SemiModularAccountBase. This account can be used as the delegate contract of an EOA with
+/// EIP-7702, where address(this) (aka the EOA address) is the default fallback signer.
+contract SemiModularAccount7702 is SemiModularAccountBase {
+    constructor(IEntryPoint anEntryPoint) SemiModularAccountBase(anEntryPoint) {}
+
+    /// @inheritdoc IModularAccount
+    function accountId() external pure override returns (string memory) {
+        return "alchemy.sma-7702.1.0.0";
+    }
+
+    /// @dev If the fallback signer is set in storage, means the fallback signer has been updated. We ignore the
+    /// address(this) EOA signer.
+    function _retrieveFallbackSignerUnchecked(SemiModularAccountStorage storage _storage)
+        internal
+        view
+        override
+        returns (address)
+    {
+        address storageFallbackSigner = _storage.fallbackSigner;
+        if (storageFallbackSigner != address(0)) {
+            return storageFallbackSigner;
+        }
+
+        return address(this);
+    }
+}

--- a/src/account/SemiModularAccount7702.sol
+++ b/src/account/SemiModularAccount7702.sol
@@ -12,11 +12,17 @@ import {SemiModularAccountBase} from "./SemiModularAccountBase.sol";
 /// @dev Inherits SemiModularAccountBase. This account can be used as the delegate contract of an EOA with
 /// EIP-7702, where address(this) (aka the EOA address) is the default fallback signer.
 contract SemiModularAccount7702 is SemiModularAccountBase {
+    error UpgradeNotAllowed();
+
     constructor(IEntryPoint anEntryPoint) SemiModularAccountBase(anEntryPoint) {}
 
     /// @inheritdoc IModularAccount
     function accountId() external pure override returns (string memory) {
         return "alchemy.sma-7702.1.0.0";
+    }
+
+    function upgradeToAndCall(address, bytes calldata) public payable override {
+        revert UpgradeNotAllowed();
     }
 
     /// @dev If the fallback signer is set in storage, means the fallback signer has been updated. We ignore the


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Support EIP-7702 EOA delegation with semi modular account.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution
Default fallback signer to `address(this)` aka EOA address for 7702 EOA account.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->