### PR TITLE
fix: [CL ALCHEMY-002] use correct validation function for running hooks in executeUserOp

### DIFF
--- a/gas-snapshots/ModularAccount.json
+++ b/gas-snapshots/ModularAccount.json
@@ -6,11 +6,11 @@
   "Runtime_NativeTransfer": "54543",
   "Runtime_UseSessionKey_Case1_Counter": "78606",
   "Runtime_UseSessionKey_Case1_Token": "111919",
-  "UserOp_BatchTransfers": "198297",
-  "UserOp_Erc20Transfer": "185250",
-  "UserOp_InstallSessionKey_Case1": "531230",
-  "UserOp_NativeTransfer": "161531",
-  "UserOp_UseSessionKey_Case1_Counter": "195236",
-  "UserOp_UseSessionKey_Case1_Token": "226220",
-  "UserOp_deferredValidation": "257289"
+  "UserOp_BatchTransfers": "198294",
+  "UserOp_Erc20Transfer": "185247",
+  "UserOp_InstallSessionKey_Case1": "531227",
+  "UserOp_NativeTransfer": "161528",
+  "UserOp_UseSessionKey_Case1_Counter": "195233",
+  "UserOp_UseSessionKey_Case1_Token": "226217",
+  "UserOp_deferredValidation": "257619"
 }

--- a/gas-snapshots/ModularAccount.json
+++ b/gas-snapshots/ModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "161528",
   "UserOp_UseSessionKey_Case1_Counter": "195233",
   "UserOp_UseSessionKey_Case1_Token": "226217",
-  "UserOp_deferredValidation": "257619"
+  "UserOp_deferredValidation": "257610"
 }

--- a/gas-snapshots/SemiModularAccount.json
+++ b/gas-snapshots/SemiModularAccount.json
@@ -6,11 +6,11 @@
   "Runtime_NativeTransfer": "50584",
   "Runtime_UseSessionKey_Case1_Counter": "78956",
   "Runtime_UseSessionKey_Case1_Token": "112269",
-  "UserOp_BatchTransfers": "193462",
-  "UserOp_Erc20Transfer": "180498",
-  "UserOp_InstallSessionKey_Case1": "528750",
-  "UserOp_NativeTransfer": "156773",
-  "UserOp_UseSessionKey_Case1_Counter": "195464",
-  "UserOp_UseSessionKey_Case1_Token": "226460",
-  "UserOp_deferredValidation": "253735"
+  "UserOp_BatchTransfers": "193459",
+  "UserOp_Erc20Transfer": "180495",
+  "UserOp_InstallSessionKey_Case1": "528747",
+  "UserOp_NativeTransfer": "156770",
+  "UserOp_UseSessionKey_Case1_Counter": "195461",
+  "UserOp_UseSessionKey_Case1_Token": "226457",
+  "UserOp_deferredValidation": "254065"
 }

--- a/gas-snapshots/SemiModularAccount.json
+++ b/gas-snapshots/SemiModularAccount.json
@@ -12,5 +12,5 @@
   "UserOp_NativeTransfer": "156770",
   "UserOp_UseSessionKey_Case1_Counter": "195461",
   "UserOp_UseSessionKey_Case1_Token": "226457",
-  "UserOp_deferredValidation": "254065"
+  "UserOp_deferredValidation": "254056"
 }

--- a/gas/modular-account/ModularAccount.gas.t.sol
+++ b/gas/modular-account/ModularAccount.gas.t.sol
@@ -288,10 +288,13 @@ contract ModularAccountGasTest is ModularAccountBenchmarkBase("ModularAccount") 
         );
 
         userOp.signature = _encodeDeferredInstallUOSignature(
-            signerValidation,
+            ValidationConfigLib.moduleEntity(newUOValidation),
             GLOBAL_VALIDATION,
             _packDeferredInstallData(
-                deferredInstallNonce, deferredInstallDeadline, newUOValidation, deferredValidationInstallCall
+                deferredInstallNonce,
+                deferredInstallDeadline,
+                ValidationConfigLib.pack(signerValidation, true, false, false),
+                deferredValidationInstallCall
             ),
             deferredValidationSig,
             uoValidationSig

--- a/gas/modular-account/SemiModularAccount.gas.t.sol
+++ b/gas/modular-account/SemiModularAccount.gas.t.sol
@@ -277,10 +277,13 @@ contract ModularAccountGasTest is ModularAccountBenchmarkBase("SemiModularAccoun
             _packFinalSignature(_signRawHash(vm, owner1Key, _getSMAReplaySafeHash(address(account1), digest)));
 
         userOp.signature = _encodeDeferredInstallUOSignature(
-            signerValidation,
+            ValidationConfigLib.moduleEntity(newUOValidation),
             GLOBAL_VALIDATION,
             _packDeferredInstallData(
-                deferredInstallNonce, deferredInstallDeadline, newUOValidation, deferredValidationInstallCall
+                deferredInstallNonce,
+                deferredInstallDeadline,
+                ValidationConfigLib.pack(signerValidation, true, false, false),
+                deferredValidationInstallCall
             ),
             deferredValidationSig,
             uoValidationSig

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -438,7 +438,7 @@ abstract contract ModularAccountBase is
             // The struct must sign over the user op validation function, nonce, deadline, and the deferred action.
             // Note that while the declared type of the UO validation is `ValidationConfig`, the flags are
             // interpretted as validation selection flags, not validation installation flags.
-            ValidationConfig uoValidation = ValidationConfig.wrap(bytes25(userOp.signature[:25]));
+            bytes25 uoValidation = bytes25(userOp.signature[:25]);
             uint48 deadline = _validateDeferredActionAndSetNonce(uoValidation, encodedData, deferredActionSig);
             // Update the validation data with the deadline.
             validationData = uint256(deadline) << 160;
@@ -476,7 +476,7 @@ abstract contract ModularAccountBase is
 
     /// @return The deadline of the deferred action
     function _validateDeferredActionAndSetNonce(
-        ValidationConfig userOpValidationFunction,
+        bytes25 userOpValidationFunction,
         bytes calldata encodedData,
         bytes calldata sig
     ) internal returns (uint48) {
@@ -1027,7 +1027,7 @@ abstract contract ModularAccountBase is
         bytes calldata selfCall,
         uint256 nonce,
         uint48 deadline,
-        ValidationConfig validationFunction
+        bytes25 validationFunction
     ) internal view returns (bytes32) {
         // bytes32 result;
 

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -413,7 +413,8 @@ abstract contract ModularAccountBase is
         ///      [(33 + deferredActionSigLength + encodedDataLength):] : bytes, userOpSignature. This is the
         ///         signature passed to the inner validation.
         if (hasDeferredAction) {
-            // Use outer validation as a 1271 validation, then use the inner validation to validate the UO.
+            // Use outer validation to validate the UO, and the inner validation as 1271 validation for the
+            // deferred action.
 
             // Get the length of the deferred action data.
             uint256 encodedDataLength = uint32(bytes4(userOp.signature[25:29]));
@@ -434,18 +435,16 @@ abstract contract ModularAccountBase is
                 userOp.signature[33 + encodedDataLength:33 + encodedDataLength + deferredActionSigLength];
 
             //Validate the signature.
-            (uint48 deadline, ValidationConfig newValidationFunction) = _validateDeferredActionAndSetNonce(
-                validationFunction, isGlobalValidation, encodedData, deferredActionSig
-            );
+            // The struct must sign over the user op validation function, nonce, deadline, and the deferred action.
+            // Note that while the declared type of the UO validation is `ValidationConfig`, the flags are
+            // interpretted as validation selection flags, not validation installation flags.
+            ValidationConfig uoValidation = ValidationConfig.wrap(bytes25(userOp.signature[:25]));
+            uint48 deadline = _validateDeferredActionAndSetNonce(uoValidation, encodedData, deferredActionSig);
             // Update the validation data with the deadline.
             validationData = uint256(deadline) << 160;
 
-            // Call `installValidation` on the account.
+            // Perform the deferred action's self call on the account.
             ExecutionLib.callBubbleOnRevertTransient(address(this), 0, encodedData[63:]);
-
-            // Load in the inner validation.
-            validationFunction = newValidationFunction.moduleEntity();
-            isGlobalValidation = newValidationFunction.isGlobal();
         } else {
             userOpSignature = userOp.signature[25:];
         }
@@ -475,26 +474,26 @@ abstract contract ModularAccountBase is
         }
     }
 
-    /// @return The deadline of the deferred action and the validation function to use.
+    /// @return The deadline of the deferred action
     function _validateDeferredActionAndSetNonce(
-        ModuleEntity sigValidation,
-        bool isGlobalValidation,
+        ValidationConfig userOpValidationFunction,
         bytes calldata encodedData,
         bytes calldata sig
-    ) internal returns (uint48, ValidationConfig) {
+    ) internal returns (uint48) {
         // Decode stack vars for the deadline and nonce.
         // The deadline, nonce, inner validation, and deferred call selector are all at fixed positions in the
         // encodedData.
         uint256 nonce = uint256(bytes32(encodedData[:32]));
         uint48 deadline = uint48(bytes6(encodedData[32:38]));
 
-        ValidationConfig uoValidation = ValidationConfig.wrap(bytes25(encodedData[38:63]));
+        ValidationConfig defActionSigValidation = ValidationConfig.wrap(bytes25(encodedData[38:63]));
+        bool isGlobalSigValidation = defActionSigValidation.isGlobal();
 
         // Check if the outer validation applies to the function call
         _checkIfValidationAppliesCallData(
             encodedData[63:],
-            sigValidation,
-            isGlobalValidation ? ValidationCheckingType.GLOBAL : ValidationCheckingType.SELECTOR
+            defActionSigValidation.moduleEntity(),
+            isGlobalSigValidation ? ValidationCheckingType.GLOBAL : ValidationCheckingType.SELECTOR
         );
 
         // Check that the passed nonce isn't already invalidated.
@@ -511,17 +510,17 @@ abstract contract ModularAccountBase is
             encodedData[63:], // The encoded call without the nonce, deadline, and validation function
             nonce,
             deadline,
-            uoValidation
+            userOpValidationFunction
         );
 
         // Clear the memory after performing signature validation
         MemSnapshot memSnapshot = MemManagementLib.freezeFMP();
-        if (_isValidSignature(sigValidation, typedDataHash, sig) != _1271_MAGIC_VALUE) {
+        if (_isValidSignature(defActionSigValidation.moduleEntity(), typedDataHash, sig) != _1271_MAGIC_VALUE) {
             revert DeferredActionSignatureInvalid();
         }
         MemManagementLib.restoreFMP(memSnapshot);
 
-        return (deadline, uoValidation);
+        return deadline;
     }
 
     // To support gas estimation, we don't fail early when the failure is caused by a signature failure

--- a/test/utils/ModuleSignatureUtils.sol
+++ b/test/utils/ModuleSignatureUtils.sol
@@ -22,7 +22,10 @@ import {Vm} from "forge-std/Vm.sol";
 import {RESERVED_VALIDATION_DATA_INDEX} from "@erc6900/reference-implementation/helpers/Constants.sol";
 import {ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
-import {ValidationConfig} from "@erc6900/reference-implementation/libraries/ValidationConfigLib.sol";
+import {
+    ValidationConfig,
+    ValidationConfigLib
+} from "@erc6900/reference-implementation/libraries/ValidationConfigLib.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 import {ModularAccount} from "../../src/account/ModularAccount.sol";
@@ -39,6 +42,8 @@ contract ModuleSignatureUtils {
 
     uint8 public constant SELECTOR_ASSOCIATED_VALIDATION = 0;
     uint8 public constant GLOBAL_VALIDATION = 1;
+    uint8 public constant HAS_DEFERRED_ACTION_BIT = 2;
+
     uint8 public constant EOA_TYPE_SIGNATURE = 0;
 
     string internal constant _DEFERRED_ACTION_CONTENTS_TYPE =
@@ -184,12 +189,20 @@ contract ModuleSignatureUtils {
         });
     }
 
+    function _packValidationLocator(ModuleEntity validationFunction, uint8 validationSettings)
+        internal
+        pure
+        returns (ValidationConfig)
+    {
+        return ValidationConfig.wrap(bytes25(abi.encodePacked(validationFunction, validationSettings)));
+    }
+
     // Deferred validation helpers
 
     // Internal Helpers
 
     function _encodeDeferredInstallUOSignature(
-        ModuleEntity installAuthorizingValidation,
+        ModuleEntity uoValidationFunction,
         uint8 globalOrNot,
         bytes memory packedDeferredInstallData,
         bytes memory deferredValidationInstallSig,
@@ -198,7 +211,7 @@ contract ModuleSignatureUtils {
         uint8 outerValidationFlags = 2 | globalOrNot;
 
         return abi.encodePacked(
-            installAuthorizingValidation,
+            uoValidationFunction,
             outerValidationFlags,
             uint32(packedDeferredInstallData.length),
             packedDeferredInstallData,
@@ -226,6 +239,10 @@ contract ModuleSignatureUtils {
         ValidationConfig validationFunction,
         bytes memory selfCall
     ) internal view returns (bytes32) {
+        ValidationConfig maskedValidationFunction = _packValidationLocator(
+            ValidationConfigLib.moduleEntity(validationFunction), GLOBAL_VALIDATION | HAS_DEFERRED_ACTION_BIT
+        );
+
         bytes32 domainSeparator = _computeDomainSeparator(address(account));
 
         bytes32 selfCallHash = keccak256(selfCall);
@@ -233,7 +250,7 @@ contract ModuleSignatureUtils {
         return MessageHashUtils.toTypedDataHash({
             domainSeparator: domainSeparator,
             structHash: keccak256(
-                abi.encode(_DEFERRED_ACTION_TYPEHASH, nonce, deadline, validationFunction, selfCallHash)
+                abi.encode(_DEFERRED_ACTION_TYPEHASH, nonce, deadline, maskedValidationFunction, selfCallHash)
             )
         });
     }

--- a/test/utils/ModuleSignatureUtils.sol
+++ b/test/utils/ModuleSignatureUtils.sol
@@ -192,9 +192,9 @@ contract ModuleSignatureUtils {
     function _packValidationLocator(ModuleEntity validationFunction, uint8 validationSettings)
         internal
         pure
-        returns (ValidationConfig)
+        returns (bytes25)
     {
-        return ValidationConfig.wrap(bytes25(abi.encodePacked(validationFunction, validationSettings)));
+        return bytes25(abi.encodePacked(validationFunction, validationSettings));
     }
 
     // Deferred validation helpers
@@ -239,7 +239,7 @@ contract ModuleSignatureUtils {
         ValidationConfig validationFunction,
         bytes memory selfCall
     ) internal view returns (bytes32) {
-        ValidationConfig maskedValidationFunction = _packValidationLocator(
+        bytes25 maskedValidationFunction = _packValidationLocator(
             ValidationConfigLib.moduleEntity(validationFunction), GLOBAL_VALIDATION | HAS_DEFERRED_ACTION_BIT
         );
 


### PR DESCRIPTION
## Motivation

Addresses CL ALCHEMY-002.

When a deferred action is used, the validation-associated exec hooks, which run within `executeUserOp`, load the wrong set of hooks by reading from the first 24 bytes of `userOp.signature`, which refers to the validation of the deferred action, rather than the user op.

## Solution

When using deferred actions, switch the encoding locations of the validation for the user op and the validation for the deferred action. This results in `executeUserOp` loading and running the correct set of hooks.

Note that while the locations are switched, the contents of the EIP-712 struct for deferred actions remains the same, so the "outer" user op validation remains what is signed over.

Also add a test to verify this behavior.