### PR TITLE
fix: [Quantstamp-ALC-14] fix execution data view for native functions

### DIFF
--- a/gas-snapshots/ModularAccount.json
+++ b/gas-snapshots/ModularAccount.json
@@ -1,16 +1,16 @@
 {
   "Runtime_AccountCreation": "176125",
-  "Runtime_BatchTransfers": "92985",
-  "Runtime_Erc20Transfer": "78394",
-  "Runtime_InstallSessionKey_Case1": "423036",
-  "Runtime_NativeTransfer": "54543",
+  "Runtime_BatchTransfers": "93045",
+  "Runtime_Erc20Transfer": "78454",
+  "Runtime_InstallSessionKey_Case1": "423148",
+  "Runtime_NativeTransfer": "54603",
   "Runtime_UseSessionKey_Case1_Counter": "78606",
   "Runtime_UseSessionKey_Case1_Token": "111919",
-  "UserOp_BatchTransfers": "198306",
-  "UserOp_Erc20Transfer": "185271",
-  "UserOp_InstallSessionKey_Case1": "531243",
-  "UserOp_NativeTransfer": "161528",
+  "UserOp_BatchTransfers": "198366",
+  "UserOp_Erc20Transfer": "185331",
+  "UserOp_InstallSessionKey_Case1": "531355",
+  "UserOp_NativeTransfer": "161588",
   "UserOp_UseSessionKey_Case1_Counter": "195233",
   "UserOp_UseSessionKey_Case1_Token": "226217",
-  "UserOp_deferredValidation": "257908"
+  "UserOp_deferredValidation": "258080"
 }

--- a/gas-snapshots/SemiModularAccount.json
+++ b/gas-snapshots/SemiModularAccount.json
@@ -1,16 +1,16 @@
 {
   "Runtime_AccountCreation": "97745",
-  "Runtime_BatchTransfers": "88968",
-  "Runtime_Erc20Transfer": "74425",
-  "Runtime_InstallSessionKey_Case1": "421585",
-  "Runtime_NativeTransfer": "50584",
+  "Runtime_BatchTransfers": "89031",
+  "Runtime_Erc20Transfer": "74488",
+  "Runtime_InstallSessionKey_Case1": "421700",
+  "Runtime_NativeTransfer": "50647",
   "Runtime_UseSessionKey_Case1_Counter": "78956",
   "Runtime_UseSessionKey_Case1_Token": "112269",
-  "UserOp_BatchTransfers": "193459",
-  "UserOp_Erc20Transfer": "180495",
-  "UserOp_InstallSessionKey_Case1": "528763",
-  "UserOp_NativeTransfer": "156770",
+  "UserOp_BatchTransfers": "193522",
+  "UserOp_Erc20Transfer": "180558",
+  "UserOp_InstallSessionKey_Case1": "528878",
+  "UserOp_NativeTransfer": "156833",
   "UserOp_UseSessionKey_Case1_Counter": "195473",
   "UserOp_UseSessionKey_Case1_Token": "226457",
-  "UserOp_deferredValidation": "253953"
+  "UserOp_deferredValidation": "254131"
 }

--- a/src/helpers/NativeFunctionDelegate.sol
+++ b/src/helpers/NativeFunctionDelegate.sol
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.26;
 
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {IModularAccountView} from "@erc6900/reference-implementation/interfaces/IModularAccountView.sol";
 import {IAccount} from "@eth-infinitism/account-abstraction/interfaces/IAccount.sol";
+import {IAccountExecute} from "@eth-infinitism/account-abstraction/interfaces/IAccountExecute.sol";
 import {IERC1155Receiver} from "@openzeppelin/contracts/interfaces/IERC1155Receiver.sol";
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
-import {ModularAccountBase} from "../account/ModularAccountBase.sol";
+import {IModularAccountBase} from "../interfaces/IModularAccountBase.sol";
 
 /// @title Native Function Delegate
 /// @author Alchemy
@@ -20,18 +23,18 @@ contract NativeFunctionDelegate {
         // check against IAccount methods
         selector == uint32(IAccount.validateUserOp.selector)
         // check against ModularAccount methods
-        || selector == uint32(ModularAccountBase.installExecution.selector)
-            || selector == uint32(ModularAccountBase.uninstallExecution.selector)
-            || selector == uint32(ModularAccountBase.installValidation.selector)
-            || selector == uint32(ModularAccountBase.uninstallValidation.selector)
-            || selector == uint32(ModularAccountBase.execute.selector)
-            || selector == uint32(ModularAccountBase.executeBatch.selector)
-            || selector == uint32(ModularAccountBase.executeWithRuntimeValidation.selector)
-            || selector == uint32(ModularAccountBase.accountId.selector)
-            || selector == uint32(ModularAccountBase.performCreate.selector)
-            || selector == uint32(ModularAccountBase.invalidateDeferredValidationInstallNonce.selector)
-            || selector == uint32(ModularAccountBase.executeUserOp.selector)
-            || selector == uint32(ModularAccountBase.isValidSignature.selector)
+        || selector == uint32(IModularAccount.installExecution.selector)
+            || selector == uint32(IModularAccount.uninstallExecution.selector)
+            || selector == uint32(IModularAccount.installValidation.selector)
+            || selector == uint32(IModularAccount.uninstallValidation.selector)
+            || selector == uint32(IModularAccount.execute.selector)
+            || selector == uint32(IModularAccount.executeBatch.selector)
+            || selector == uint32(IModularAccount.executeWithRuntimeValidation.selector)
+            || selector == uint32(IModularAccount.accountId.selector)
+            || selector == uint32(IAccountExecute.executeUserOp.selector)
+            || selector == uint32(IModularAccountBase.performCreate.selector)
+            || selector == uint32(IModularAccountBase.invalidateDeferredValidationInstallNonce.selector)
+            || selector == uint32(IERC1271.isValidSignature.selector)
         // check against IModularAccountView methods
         || selector == uint32(IModularAccountView.getExecutionData.selector)
             || selector == uint32(IModularAccountView.getValidationData.selector)

--- a/src/interfaces/IModularAccountBase.sol
+++ b/src/interfaces/IModularAccountBase.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+interface IModularAccountBase {
+    /// @notice Create a contract.
+    /// @param value The value to send to the new contract constructor
+    /// @param initCode The initCode to deploy.
+    /// @param isCreate2 The bool to indicate which method to use to deploy.
+    /// @param salt The salt for deployment.
+    /// @return createdAddr The created contract address.
+    function performCreate(uint256 value, bytes calldata initCode, bool isCreate2, bytes32 salt)
+        external
+        payable
+        returns (address createdAddr);
+
+    /// @notice Invalidate a nonce for deferred actions
+    /// @param nonce the nonce to invalidate.
+    function invalidateDeferredValidationInstallNonce(uint256 nonce) external;
+}


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Execution data view method is not returning the correct fields for native functions. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

Return correct fields for the following two types of native functions. Needed to create an interface to avoid circular dependency. It also helps the MA readability now that all external funcs have interfaces.
* Native view functions
* Other native functions

Also refactored `NativeFunctionDelegate` to import interfaces when available.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->