### PR TITLE
fix: [QS-S2] Comment and documentation update

### DIFF
--- a/src/account/ModularAccount.sol
+++ b/src/account/ModularAccount.sol
@@ -15,7 +15,7 @@ import {ModularAccountBase} from "./ModularAccountBase.sol";
 contract ModularAccount is ModularAccountBase {
     constructor(IEntryPoint anEntryPoint) ModularAccountBase(anEntryPoint) {}
 
-    /// @notice Initializes the account with a validation function added to the global pool.
+    /// @notice Initializes the account with a validation function.
     /// @dev This function is only callable once.
     function initializeWithValidation(
         ValidationConfig validationConfig,

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -922,7 +922,7 @@ abstract contract ModularAccountBase is
     ) internal view {
         // Equivalent to the following code, but without using memory.
 
-        // (Call[] memory calls) = abi.decode(callData[4:], (Call[]));
+        // (Call[] memory calls) = abi.decode(callData, (Call[]));
 
         // for (uint256 i = 0; i < calls.length; ++i) {
         //     if (calls[i].target == address(this)) {

--- a/src/helpers/NativeFunctionDelegate.sol
+++ b/src/helpers/NativeFunctionDelegate.sol
@@ -15,7 +15,7 @@ import {IModularAccountBase} from "../interfaces/IModularAccountBase.sol";
 
 /// @title Native Function Delegate
 /// @author Alchemy
-/// @dev This is a simple contract meant to be delegatecalled to determine whether a ModularAccountBase function
+/// @dev This is a simple contract meant to be called to determine whether a ModularAccountBase function
 /// selector is native to the account implementation.
 contract NativeFunctionDelegate {
     function isNativeFunction(uint32 selector) external pure returns (bool) {

--- a/src/libraries/MemManagementLib.sol
+++ b/src/libraries/MemManagementLib.sol
@@ -95,7 +95,7 @@ library MemManagementLib {
 
         SetValue[] memory hooksSet = LinkedListSetLib.getAll(execData.executionHooks);
 
-        // SetValue is internally a bytes30, and HookConfig is a bytes25, which are both left-aligned. This cast is
+        // SetValue is internally a bytes31, and HookConfig is a bytes25, which are both left-aligned. This cast is
         // safe so long as only HookConfig entries are added to the set.
         assembly ("memory-safe") {
             hooks := hooksSet
@@ -128,7 +128,7 @@ library MemManagementLib {
     function loadSelectors(ValidationStorage storage valData) internal view returns (bytes4[] memory selectors) {
         SetValue[] memory selectorsSet = LinkedListSetLib.getAll(valData.selectors);
 
-        // SetValue is internally a bytes30, and both bytes4 and bytes30 are left-aligned. This cast is safe so
+        // SetValue is internally a bytes31, and both bytes4 and bytes31 are left-aligned. This cast is safe so
         // long as only bytes4 entries are added to the set.
         assembly ("memory-safe") {
             selectors := selectorsSet

--- a/test/account/ModularAccount.t.sol
+++ b/test/account/ModularAccount.t.sol
@@ -583,7 +583,7 @@ contract ModularAccountTest is AccountTestBase {
         account1.performCreate(0, abi.encodePacked(type(MockRevertingConstructor).creationCode), false, 0);
     }
 
-    function test_performCreate2() public withSMATest {
+    function test_performCreate_create2() public withSMATest {
         bytes memory initCode =
             abi.encodePacked(type(ModularAccount).creationCode, abi.encode(address(entryPoint)));
         bytes32 initCodeHash = keccak256(initCode);


### PR DESCRIPTION
## Motivation

Addresses QS-S2.

## Solution

Update comments and documentation to reflect the latest code changes.

Two of the comments changes are addressed in #299 instead:
- `invalidateDeferredValidationInstallNonce` is removed
- The deferred action type hash computation function has a new name.