### PR TITLE
fix: [ALC-2] check paymaster address in hook as well

### DIFF
--- a/src/modules/permissions/PaymasterGuardModule.sol
+++ b/src/modules/permissions/PaymasterGuardModule.sol
@@ -65,11 +65,13 @@ contract PaymasterGuardModule is ModuleBase, IValidationHookModule {
         returns (uint256)
     {
         address payingPaymaster = address(bytes20(userOp.paymasterAndData[:20]));
-        if (payingPaymaster == paymasters[entityId][msg.sender]) {
-            return 0;
-        } else {
+        if (payingPaymaster == address(0)) {
+            revert InvalidPaymaster();
+        }
+        if (payingPaymaster != paymasters[entityId][msg.sender]) {
             revert BadPaymasterSpecified();
         }
+        return 0;
     }
 
     /// @inheritdoc IValidationHookModule


### PR DESCRIPTION
> Due to the fact that the onInstall() callback at installation is optional, the paymasters[entityId][msg.sender] mapping could remain unset at installation, therefore potentially still resolving to the zero slot.