### PR TITLE
feat: Add Module Deployment Address Prediction Script

### DIFF
--- a/script/DeployModules.s.sol
+++ b/script/DeployModules.s.sol
@@ -3,14 +3,6 @@ pragma solidity ^0.8.26;
 
 import {console} from "forge-std/console.sol";
 
-import {AllowlistModule} from "../src/modules/permissions/AllowlistModule.sol";
-import {NativeTokenLimitModule} from "../src/modules/permissions/NativeTokenLimitModule.sol";
-import {PaymasterGuardModule} from "../src/modules/permissions/PaymasterGuardModule.sol";
-
-import {TimeRangeModule} from "../src/modules/permissions/TimeRangeModule.sol";
-import {SingleSignerValidationModule} from "../src/modules/validation/SingleSignerValidationModule.sol";
-import {WebAuthnValidationModule} from "../src/modules/validation/WebAuthnValidationModule.sol";
-
 import {Artifacts} from "./Artifacts.sol";
 import {ScriptBase} from "./ScriptBase.sol";
 
@@ -64,7 +56,7 @@ contract DeployModulesScript is ScriptBase, Artifacts {
         webAuthnValidationModuleSalt = vm.envOr("WEBAUTHN_VALIDATION_MODULE_SALT", uint256(0));
     }
 
-    function run() public onlyProfile("optimized-build"){
+    function run() public onlyProfile("optimized-build") {
         console.log("******** Deploying Modules *********");
 
         vm.startBroadcast();

--- a/script/GetInitcodeHash.s.sol
+++ b/script/GetInitcodeHash.s.sol
@@ -9,8 +9,8 @@ import {ModularAccount} from "../src/account/ModularAccount.sol";
 import {SemiModularAccountBytecode} from "../src/account/SemiModularAccountBytecode.sol";
 import {ExecutionInstallDelegate} from "../src/helpers/ExecutionInstallDelegate.sol";
 
-import {ScriptBase} from "./ScriptBase.sol";
 import {Artifacts} from "./Artifacts.sol";
+import {ScriptBase} from "./ScriptBase.sol";
 
 // Logs all initcode hashes from deployment artifacts.
 // Generates in order of dependencies:
@@ -33,7 +33,6 @@ import {Artifacts} from "./Artifacts.sol";
 
 contract GetInitcodeHashScript is ScriptBase, Artifacts {
     function run() public view onlyProfile("optimized-build") {
-
         console.log("******** Calculating Initcode Hashes *********");
 
         console.log("Artifact initcode hashes with no dependencies:");

--- a/script/PredictModules.s.sol
+++ b/script/PredictModules.s.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.26;
+
+import {console} from "forge-std/console.sol";
+
+import {Artifacts} from "./Artifacts.sol";
+import {ScriptBase} from "./ScriptBase.sol";
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+
+// Predicts addresses for all standalone modules with salts taken from the environment.
+// - AllowlistModule
+// - NativeTokenLimitModule
+// - PaymasterGuardModule
+// - SingleSignerValidationModule
+// - TimeRangeModule
+// - WebAuthnValidationModule
+contract DeployModulesScript is ScriptBase, Artifacts {
+    // State vars for salts.
+
+    uint256 public allowlistModuleSalt;
+    uint256 public nativeTokenLimitModuleSalt;
+    uint256 public paymasterGuardModuleSalt;
+    uint256 public singleSignerValidationModuleSalt;
+    uint256 public timeRangeModuleSalt;
+    uint256 public webAuthnValidationModuleSalt;
+
+    function setUp() public {
+        // Load the salts from env vars.
+
+        allowlistModuleSalt = vm.envOr("ALLOWLIST_MODULE_SALT", uint256(0));
+        nativeTokenLimitModuleSalt = vm.envOr("NATIVE_TOKEN_LIMIT_MODULE_SALT", uint256(0));
+        paymasterGuardModuleSalt = vm.envOr("PAYMASTER_GUARD_MODULE_SALT", uint256(0));
+        singleSignerValidationModuleSalt = vm.envOr("SINGLE_SIGNER_VALIDATION_MODULE_SALT", uint256(0));
+        timeRangeModuleSalt = vm.envOr("TIME_RANGE_MODULE_SALT", uint256(0));
+        webAuthnValidationModuleSalt = vm.envOr("WEBAUTHN_VALIDATION_MODULE_SALT", uint256(0));
+    }
+
+    function run() public view onlyProfile("optimized-build") {
+        console.log("******** Logging Expected Module Addresses With Env Salts *********");
+
+        console.log(
+            "ALLOWLIST_MODULE=",
+            Create2.computeAddress(
+                bytes32(allowlistModuleSalt), keccak256(_getAllowlistModuleInitcode()), CREATE2_FACTORY
+            )
+        );
+
+        console.log(
+            "NATIVE_TOKEN_LIMIT_MODULE=",
+            Create2.computeAddress(
+                bytes32(nativeTokenLimitModuleSalt),
+                keccak256(_getNativeTokenLimitModuleInitcode()),
+                CREATE2_FACTORY
+            )
+        );
+
+        console.log(
+            "PAYMASTER_GUARD_MODULE=",
+            Create2.computeAddress(
+                bytes32(paymasterGuardModuleSalt), keccak256(_getPaymasterGuardModuleInitcode()), CREATE2_FACTORY
+            )
+        );
+
+        console.log(
+            "SINGLE_SIGNER_VALIDATION_MODULE=",
+            Create2.computeAddress(
+                bytes32(singleSignerValidationModuleSalt),
+                keccak256(_getSingleSignerValidationModuleInitcode()),
+                CREATE2_FACTORY
+            )
+        );
+
+        console.log(
+            "TIME_RANGE_MODULE=",
+            Create2.computeAddress(
+                bytes32(timeRangeModuleSalt), keccak256(_getTimeRangeModuleInitcode()), CREATE2_FACTORY
+            )
+        );
+
+        console.log(
+            "WEBAUTHN_VALIDATION_MODULE=",
+            Create2.computeAddress(
+                bytes32(webAuthnValidationModuleSalt),
+                keccak256(_getWebAuthnValidationModuleInitcode()),
+                CREATE2_FACTORY
+            )
+        );
+    }
+}

--- a/script/PredictModules.s.sol
+++ b/script/PredictModules.s.sol
@@ -14,7 +14,7 @@ import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 // - SingleSignerValidationModule
 // - TimeRangeModule
 // - WebAuthnValidationModule
-contract DeployModulesScript is ScriptBase, Artifacts {
+contract PredictModulesScript is ScriptBase, Artifacts {
     // State vars for salts.
 
     uint256 public allowlistModuleSalt;

--- a/test/script/DeployModules.s.t.sol
+++ b/test/script/DeployModules.s.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 
-import {EntryPoint} from "@eth-infinitism/account-abstraction/core/EntryPoint.sol";
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 import {AllowlistModule} from "../../src/modules/permissions/AllowlistModule.sol";


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

Simple PR to add a script to print out the module addresses predicted using the salts from the environment (or zero by default).

This makes it easier to run deployment scripts by providing an easy to copy-paste solution for printing out all expected module addresses for the module deploy script.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

Add a script which prints out expected module addresses.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->