### PR TITLE
chore: final review fixes

### DIFF
--- a/src/libraries/ValidationLocatorLib.sol
+++ b/src/libraries/ValidationLocatorLib.sol
@@ -306,18 +306,14 @@ library ValidationLocatorLib {
         result <<= 64;
     }
 
-    function packSignature(
-        uint32 validationEntityId,
-        bool _isGlobal,
-        bool _hasDeferredAction,
-        bytes memory signature
-    ) internal pure returns (bytes memory result) {
+    function packSignature(uint32 validationEntityId, bool _isGlobal, bytes memory signature)
+        internal
+        pure
+        returns (bytes memory result)
+    {
         uint8 options = 0;
         if (_isGlobal) {
             options |= _VALIDATION_TYPE_GLOBAL;
-        }
-        if (_hasDeferredAction) {
-            options |= _HAS_DEFERRED_ACTION;
         }
 
         return bytes.concat(abi.encodePacked(options, uint32(validationEntityId)), signature);

--- a/src/libraries/ValidationLocatorLib.sol
+++ b/src/libraries/ValidationLocatorLib.sol
@@ -179,14 +179,14 @@ library ValidationLocatorLib {
     // Only safe to call if the lookup has been asserted to be a direct call validation.
     function directCallAddress(ValidationLookupKey _lookupKey) internal pure returns (address result) {
         assembly ("memory-safe") {
-            result := shr(8, _lookupKey)
+            result := and(shr(8, _lookupKey), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
         }
     }
 
     // Only safe to call if the lookup has been asserted to be a non-direct call validation.
     function entityId(ValidationLookupKey _lookupKey) internal pure returns (uint32 result) {
         assembly ("memory-safe") {
-            result := shr(8, _lookupKey)
+            result := and(shr(8, _lookupKey), 0xFFFFFFFF)
         }
     }
 

--- a/src/libraries/ValidationLocatorLib.sol
+++ b/src/libraries/ValidationLocatorLib.sol
@@ -176,14 +176,14 @@ library ValidationLocatorLib {
     // Only safe to call if the lookup has been asserted to be a direct call validation.
     function directCallAddress(ValidationLookupKey _lookupKey) internal pure returns (address result) {
         assembly ("memory-safe") {
-            result := and(shr(8, _lookupKey), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+            result := shr(8, _lookupKey)
         }
     }
 
     // Only safe to call if the lookup has been asserted to be a non-direct call validation.
     function entityId(ValidationLookupKey _lookupKey) internal pure returns (uint32 result) {
         assembly ("memory-safe") {
-            result := and(shr(8, _lookupKey), 0xFFFFFFFFFFFFFFFF)
+            result := shr(8, _lookupKey)
         }
     }
 

--- a/src/libraries/ValidationLocatorLib.sol
+++ b/src/libraries/ValidationLocatorLib.sol
@@ -47,6 +47,9 @@ type ValidationLocator is uint168;
 // direct call validation flag.
 type ValidationLookupKey is uint168;
 
+using ValidationLocatorLib for ValidationLocator global;
+using ValidationLocatorLib for ValidationLookupKey global;
+
 library ValidationLocatorLib {
     using ValidationConfigLib for ValidationConfig;
 
@@ -368,6 +371,3 @@ library ValidationLocatorLib {
         return ValidationLookupKey.unwrap(a) == ValidationLookupKey.unwrap(b);
     }
 }
-
-using ValidationLocatorLib for ValidationLocator global;
-using ValidationLocatorLib for ValidationLookupKey global;

--- a/test/libraries/ValidationLocatorLib.t.sol
+++ b/test/libraries/ValidationLocatorLib.t.sol
@@ -71,6 +71,22 @@ contract ValidationLocatorLibTest is Test {
         assertEq(remainder, signature);
     }
 
+    function testFuzz_packUnpackLookupKey(uint32 entityId) public pure {
+        ValidationLookupKey k = ValidationLookupKey.wrap(uint168(uint160(entityId)) << 8);
+
+        uint32 expected = ValidationLocatorLib.entityId(k);
+
+        assertEq(expected, entityId);
+    }
+
+    function testFuzz_packUnpackDirectCallAddress(address directCallValidation) public pure {
+        ValidationLookupKey k = ValidationLookupKey.wrap(uint168(uint160(directCallValidation)) << 8);
+
+        address expected = ValidationLocatorLib.directCallAddress(k);
+
+        assertEq(expected, directCallValidation);
+    }
+
     function testFuzz_loadFromSignature_directCall(
         address directCallValidation,
         bool isGlobal,

--- a/test/libraries/ValidationLocatorLib.t.sol
+++ b/test/libraries/ValidationLocatorLib.t.sol
@@ -57,18 +57,15 @@ contract ValidationLocatorLibTest is Test {
         assertEq(ValidationLocator.unwrap(result), ValidationLocator.unwrap(expected));
     }
 
-    function testFuzz_loadFromSignature_regular(
-        uint32 entityId,
-        bool isGlobal,
-        bool isDeferredAction,
-        bytes memory signature
-    ) public view {
-        bytes memory finalSignature =
-            ValidationLocatorLib.packSignature(entityId, isGlobal, isDeferredAction, signature);
+    function testFuzz_loadFromSignature_regular(uint32 entityId, bool isGlobal, bytes memory signature)
+        public
+        view
+    {
+        bytes memory finalSignature = ValidationLocatorLib.packSignature(entityId, isGlobal, signature);
 
         (ValidationLocator result, bytes memory remainder) = this.loadFromSignature(finalSignature);
 
-        ValidationLocator expected = ValidationLocatorLib.pack(entityId, isGlobal, isDeferredAction);
+        ValidationLocator expected = ValidationLocatorLib.pack(entityId, isGlobal, false);
 
         assertEq(ValidationLocator.unwrap(result), ValidationLocator.unwrap(expected));
         assertEq(remainder, signature);

--- a/test/libraries/ValidationLocatorLib.t.sol
+++ b/test/libraries/ValidationLocatorLib.t.sol
@@ -71,12 +71,10 @@ contract ValidationLocatorLibTest is Test {
         assertEq(remainder, signature);
     }
 
-    function testFuzz_packUnpackLookupKey(uint32 entityId) public pure {
-        ValidationLookupKey k = ValidationLookupKey.wrap(uint168(uint160(entityId)) << 8);
+    function testFuzz_packUnpackLookupKey(uint168 id) public pure {
+        ValidationLookupKey k = ValidationLookupKey.wrap(id << 8);
 
-        uint32 expected = ValidationLocatorLib.entityId(k);
-
-        assertEq(expected, entityId);
+        assertEq(uint32(id), ValidationLocatorLib.entityId(k));
     }
 
     function testFuzz_packUnpackDirectCallAddress(address directCallValidation) public pure {

--- a/test/utils/ModuleSignatureUtils.sol
+++ b/test/utils/ModuleSignatureUtils.sol
@@ -102,7 +102,7 @@ contract ModuleSignatureUtils {
             sig =
                 ValidationLocatorLib.packSignatureDirectCall(module, globalOrNot == GLOBAL_VALIDATION, false, sig);
         } else {
-            sig = ValidationLocatorLib.packSignature(entityId, globalOrNot == GLOBAL_VALIDATION, false, sig);
+            sig = ValidationLocatorLib.packSignature(entityId, globalOrNot == GLOBAL_VALIDATION, sig);
         }
 
         return sig;
@@ -140,7 +140,7 @@ contract ModuleSignatureUtils {
         if (entityId == DIRECT_CALL_VALIDATION_ENTITY_ID) {
             sig = ValidationLocatorLib.packSignatureDirectCall(module, false, false, sig);
         } else {
-            sig = ValidationLocatorLib.packSignature(entityId, false, false, sig);
+            sig = ValidationLocatorLib.packSignature(entityId, false, sig);
         }
 
         return sig;


### PR DESCRIPTION
1. Move all global "using" statements to the top of the library file
2. Remove redundant bit masking operations being performed for some library helper functions
3. Removed redundant variable and flag in a library helper function 