### PR TITLE
Fix Typo in Documentation and Update EIP-712 Helpers Comments

### DIFF
--- a/test/invariant/handlers/LinkedListSetHandler.sol
+++ b/test/invariant/handlers/LinkedListSetHandler.sol
@@ -31,7 +31,7 @@ import {
 } from "../../../src/libraries/LinkedListSetLib.sol";
 
 /// @notice A handler contract for differential invariant testing LinkedListSetLib
-///         This contract maps logic for adding, removeing, clearing, and inspecting a list
+///         This contract maps logic for adding, removing, clearing, and inspecting a list
 ///         to a reference implementation using EnumerableSet.Bytes32Set, which the invariant
 ///         fuzzer can then use to test the library.
 contract LinkedListSetHandler is CommonBase, StdCheats, StdUtils {

--- a/test/utils/ModuleSignatureUtils.sol
+++ b/test/utils/ModuleSignatureUtils.sol
@@ -312,12 +312,12 @@ contract ModuleSignatureUtils {
         });
     }
 
-    // EIP-712 helpers for acount
+    // EIP-712 helpers for account
     function _computeDomainSeparator(address account) internal view returns (bytes32) {
         return keccak256(abi.encode(_ACCOUNT_DOMAIN_SEPARATOR, block.chainid, account));
     }
 
-    // EIP-712 helpers for acount
+    // EIP-712 helpers for account
     function _hashStruct(bytes32 hash) internal pure virtual returns (bytes32) {
         return keccak256(abi.encode(_REPLAY_SAFE_HASH_TYPEHASH, hash));
     }


### PR DESCRIPTION

Description:  
This pull request addresses the following changes:
- Corrects a typo in the documentation of `LinkedListSetHandler.sol` by changing "removeing" to "removing".
- Updates comments in `ModuleSignatureUtils.sol` for EIP-712 helpers, ensuring consistent spelling of "account".

These changes improve code readability and maintain consistency in documentation and comments. No functional code changes were made.
