### PR TITLE
chore: update config for latest foundry changes

### DIFF
--- a/.github/workflows/setup-ci/action.yml
+++ b/.github/workflows/setup-ci/action.yml
@@ -6,8 +6,6 @@ runs:
   steps:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
 
       - name: "Install Pnpm"
         uses: "pnpm/action-setup@v4"

--- a/foundry.toml
+++ b/foundry.toml
@@ -16,6 +16,9 @@ fs_permissions = [
   { access = "read", path = "./test/bin" },
 ]
 
+[lint]
+exclude_lints = ["unsafe-typecast"]
+
 [fuzz]
 runs = 500
 
@@ -25,7 +28,7 @@ fail_on_revert = true
 depth = 10
 
 [profile.optimized-build]
-deny_warnings = true
+deny = 'warnings'
 via_ir = true
 test = 'src'
 optimizer_runs = 50000
@@ -33,7 +36,7 @@ out = 'out-optimized'
 cache_path = 'cache-optimized'
 
 [profile.optimized-build-standalone]
-deny_warnings = true
+deny = 'warnings'
 via_ir = true
 test = 'src'
 optimizer_runs = 10000000
@@ -41,7 +44,7 @@ out = 'out-optimized-standalone'
 cache_path = 'cache-optimized-standalone'
 
 [profile.optimized-build-sma-storage]
-deny_warnings = true
+deny = 'warnings'
 via_ir = true
 test = 'src'
 optimizer_runs = 15000
@@ -49,11 +52,11 @@ out = 'out-optimized-sma-storage'
 cache_path = 'cache-optimized-sma-storage'
 
 [profile.optimized-test]
-deny_warnings = true
+deny = 'warnings'
 src = 'test'
 
 [profile.optimized-test-deep]
-deny_warnings = true
+deny = 'warnings'
 src = 'test'
 
 [profile.optimized-test-deep.fuzz]
@@ -72,7 +75,7 @@ depth = 32
 
 [profile.gas]
 via_ir = true
-deny_warnings = true
+deny = 'warnings'
 test = 'gas'
 optimizer_runs = 50000
 out = 'out-optimized'

--- a/gas/BenchmarkBase.sol
+++ b/gas/BenchmarkBase.sol
@@ -82,11 +82,7 @@ abstract contract BenchmarkBase is OptimizedTest {
         return bType == BenchmarkType.RUNTIME ? "Runtime" : "UserOp";
     }
 
-    function _encodeGasLimits(uint128 callGasLimit, uint128 verificationGasLimit)
-        internal
-        pure
-        returns (bytes32)
-    {
+    function _encodeGasLimits(uint128 callGasLimit, uint128 verificationGasLimit) internal pure returns (bytes32) {
         return bytes32(uint256(verificationGasLimit) << 128 | uint256(callGasLimit));
     }
 

--- a/gas/modular-account/ModularAccount.gas.t.sol
+++ b/gas/modular-account/ModularAccount.gas.t.sol
@@ -173,9 +173,7 @@ contract ModularAccountGasTest is ModularAccountBenchmarkBase("ModularAccount") 
         Call[] memory calls = new Call[](2);
         calls[0] = Call({target: recipient, value: 0.1 ether, data: ""});
         calls[1] = Call({
-            target: address(mockErc20),
-            value: 0,
-            data: abi.encodeCall(mockErc20.transfer, (recipient, 10 ether))
+            target: address(mockErc20), value: 0, data: abi.encodeCall(mockErc20.transfer, (recipient, 10 ether))
         });
 
         uint256 gasUsed = _runtimeBenchmark(
@@ -205,9 +203,7 @@ contract ModularAccountGasTest is ModularAccountBenchmarkBase("ModularAccount") 
         Call[] memory calls = new Call[](2);
         calls[0] = Call({target: recipient, value: 0.1 ether, data: ""});
         calls[1] = Call({
-            target: address(mockErc20),
-            value: 0,
-            data: abi.encodeCall(mockErc20.transfer, (recipient, 10 ether))
+            target: address(mockErc20), value: 0, data: abi.encodeCall(mockErc20.transfer, (recipient, 10 ether))
         });
 
         PackedUserOperation memory userOp = PackedUserOperation({

--- a/gas/modular-account/ModularAccountBenchmarkBase.sol
+++ b/gas/modular-account/ModularAccountBenchmarkBase.sol
@@ -146,10 +146,7 @@ abstract contract ModularAccountBenchmarkBase is BenchmarkBase, ModuleSignatureU
         // ERC-20 spend limit hook
         hooks[2] = abi.encodePacked(
             HookConfigLib.packExecHook({
-                _module: address(allowlistModule),
-                _entityId: 0,
-                _hasPre: true,
-                _hasPost: false
+                _module: address(allowlistModule), _entityId: 0, _hasPre: true, _hasPost: false
             }),
             ""
         );
@@ -194,10 +191,7 @@ abstract contract ModularAccountBenchmarkBase is BenchmarkBase, ModuleSignatureU
             HookConfig.unwrap(validationData.executionHooks[0]),
             HookConfig.unwrap(
                 HookConfigLib.packExecHook({
-                    _module: address(allowlistModule),
-                    _entityId: 0,
-                    _hasPre: true,
-                    _hasPost: false
+                    _module: address(allowlistModule), _entityId: 0, _hasPre: true, _hasPost: false
                 })
             )
         );

--- a/gas/modular-account/SemiModularAccount.gas.t.sol
+++ b/gas/modular-account/SemiModularAccount.gas.t.sol
@@ -167,9 +167,7 @@ contract ModularAccountGasTest is ModularAccountBenchmarkBase("SemiModularAccoun
         Call[] memory calls = new Call[](2);
         calls[0] = Call({target: recipient, value: 0.1 ether, data: ""});
         calls[1] = Call({
-            target: address(mockErc20),
-            value: 0,
-            data: abi.encodeCall(mockErc20.transfer, (recipient, 10 ether))
+            target: address(mockErc20), value: 0, data: abi.encodeCall(mockErc20.transfer, (recipient, 10 ether))
         });
 
         uint256 gasUsed = _runtimeBenchmark(
@@ -199,9 +197,7 @@ contract ModularAccountGasTest is ModularAccountBenchmarkBase("SemiModularAccoun
         Call[] memory calls = new Call[](2);
         calls[0] = Call({target: recipient, value: 0.1 ether, data: ""});
         calls[1] = Call({
-            target: address(mockErc20),
-            value: 0,
-            data: abi.encodeCall(mockErc20.transfer, (recipient, 10 ether))
+            target: address(mockErc20), value: 0, data: abi.encodeCall(mockErc20.transfer, (recipient, 10 ether))
         });
 
         PackedUserOperation memory userOp = PackedUserOperation({

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:gas": "solhint --max-warnings 0 -c ./config/solhint-gas.json './gas/**/*.sol'",
     "lint:script": "solhint --max-warnings 0 -c ./config/solhint-script.json './script/**/*.sol'",
     "prep": "pnpm fmt && forge b --deny-warnings && pnpm lint && pnpm test && pnpm gas",
-    "sizes": "FOUNDRY_PROFILE=optimized-build forge b --sizes | grep '^|' | grep -v -e '| 17               |' -e 'Lib'",
+    "sizes": "FOUNDRY_PROFILE=optimized-build forge b --sizes --md | grep '^|' | grep -v -e '| 17               |' -e 'Lib'",
     "test": "forge test"
   }
 }

--- a/script/DeploySmaStorage.s.sol
+++ b/script/DeploySmaStorage.s.sol
@@ -60,9 +60,10 @@ contract DeploySmaStorageScript is ScriptBase, Artifacts {
     // without affecting the expected signature from _safeDeploy.
 
     function _wrappedDeploySemiModularAccountStorageOnly(bytes32 salt) internal returns (address) {
-        return _deploySemiModularAccountStorageOnly(
-            salt, entryPoint, ExecutionInstallDelegate(executionInstallDelegate)
-        );
+        return
+            _deploySemiModularAccountStorageOnly(
+                salt, entryPoint, ExecutionInstallDelegate(executionInstallDelegate)
+            );
     }
 
     function _ensureNonzeroArgs() internal view {

--- a/script/ScriptBase.sol
+++ b/script/ScriptBase.sol
@@ -74,7 +74,7 @@ abstract contract ScriptBase is Script {
         address expectedAddress,
         uint256 salt,
         bytes memory creationCode,
-        function (bytes32) internal returns (address) deployFunction
+        function(bytes32) internal returns (address) deployFunction
     ) internal {
         console.log(string.concat("Deploying ", contractName, " with salt: ", vm.toString(salt)));
 

--- a/src/account/ModularAccount.sol
+++ b/src/account/ModularAccount.sol
@@ -17,9 +17,7 @@
 
 pragma solidity ^0.8.26;
 
-import {
-    IModularAccount, ValidationConfig
-} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IModularAccount, ValidationConfig} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 
 import {ExecutionInstallDelegate} from "../helpers/ExecutionInstallDelegate.sol";

--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -54,9 +54,7 @@ import {
 } from "../libraries/ExecutionLib.sol";
 import {LinkedListSet, LinkedListSetLib} from "../libraries/LinkedListSetLib.sol";
 import {MemManagementLib, MemSnapshot} from "../libraries/MemManagementLib.sol";
-import {
-    ValidationLocator, ValidationLocatorLib, ValidationLookupKey
-} from "../libraries/ValidationLocatorLib.sol";
+import {ValidationLocator, ValidationLocatorLib, ValidationLookupKey} from "../libraries/ValidationLocatorLib.sol";
 import {AccountBase} from "./AccountBase.sol";
 import {AccountStorage, ValidationStorage, getAccountStorage, toSetValue} from "./AccountStorage.sol";
 import {AccountStorageInitializable} from "./AccountStorageInitializable.sol";
@@ -994,7 +992,9 @@ abstract contract ModularAccountBase is
                 if gt(structRelOffset, 0xffffffffffffffff) { revert(0, 0) }
                 // Validate struct offset. If the offset points to a location with < 3 words of space before the
                 // end of data, revert.
-                if iszero(slt(structRelOffset, sub(sub(dataEnd, arrayPos), sub(0x60, 1)))) { revert(0, 0) }
+                if iszero(slt(structRelOffset, sub(sub(dataEnd, arrayPos), sub(0x60, 1)))) {
+                    revert(0, 0)
+                }
 
                 structAbsOffset := add(arrayPos, structRelOffset)
 

--- a/src/account/ModularAccountView.sol
+++ b/src/account/ModularAccountView.sol
@@ -77,8 +77,8 @@ abstract contract ModularAccountView is IModularAccountView {
         override
         returns (ValidationDataView memory data)
     {
-        ValidationStorage storage validationStorage =
-            getAccountStorage().validationStorage[ValidationLocatorLib.moduleEntityToLookupKey(validationFunction)];
+        ValidationStorage storage validationStorage = getAccountStorage()
+        .validationStorage[ValidationLocatorLib.moduleEntityToLookupKey(validationFunction)];
         data.validationFlags = validationStorage.validationFlags;
         data.validationHooks = MemManagementLib.loadValidationHooks(validationStorage);
         MemManagementLib.reverseArr(data.validationHooks);
@@ -93,8 +93,7 @@ abstract contract ModularAccountView is IModularAccountView {
     }
 
     function _isNativeFunction(uint32 selector) internal pure virtual returns (bool) {
-        return (
-            _isGlobalValidationAllowedNativeFunction(selector)
+        return (_isGlobalValidationAllowedNativeFunction(selector)
                 || selector == uint32(AccountBase.entryPoint.selector)
                 || selector == uint32(AccountBase.validateUserOp.selector)
                 || selector == uint32(IERC1155Receiver.onERC1155BatchReceived.selector)
@@ -105,30 +104,25 @@ abstract contract ModularAccountView is IModularAccountView {
                 || selector == uint32(IModularAccount.accountId.selector)
                 || selector == uint32(IModularAccountView.getExecutionData.selector)
                 || selector == uint32(IModularAccountView.getValidationData.selector)
-                || selector == uint32(UUPSUpgradeable.proxiableUUID.selector)
-        );
+                || selector == uint32(UUPSUpgradeable.proxiableUUID.selector));
     }
 
     /// @dev Check whether a function is a native function that allows global validation.
     function _isGlobalValidationAllowedNativeFunction(uint32 selector) internal pure virtual returns (bool) {
-        return (
-            _isWrappedNativeFunction(selector) || selector == uint32(IAccountExecute.executeUserOp.selector)
-                || selector == uint32(IModularAccount.executeWithRuntimeValidation.selector)
-        );
+        return (_isWrappedNativeFunction(selector) || selector == uint32(IAccountExecute.executeUserOp.selector)
+                || selector == uint32(IModularAccount.executeWithRuntimeValidation.selector));
     }
 
     /// @dev Check whether a function is a native function that has the `wrapNativeFunction` modifier applied,
     /// which means it runs execution hooks associated with its selector.
     function _isWrappedNativeFunction(uint32 selector) internal pure virtual returns (bool) {
-        return (
-            selector == uint32(IModularAccount.execute.selector)
+        return (selector == uint32(IModularAccount.execute.selector)
                 || selector == uint32(IModularAccount.executeBatch.selector)
                 || selector == uint32(IModularAccount.installExecution.selector)
                 || selector == uint32(IModularAccount.installValidation.selector)
                 || selector == uint32(IModularAccount.uninstallExecution.selector)
                 || selector == uint32(IModularAccount.uninstallValidation.selector)
                 || selector == uint32(IModularAccountBase.performCreate.selector)
-                || selector == uint32(UUPSUpgradeable.upgradeToAndCall.selector)
-        );
+                || selector == uint32(UUPSUpgradeable.upgradeToAndCall.selector));
     }
 }

--- a/src/account/ModuleManagerInternals.sol
+++ b/src/account/ModuleManagerInternals.sol
@@ -99,8 +99,8 @@ abstract contract ModuleManagerInternals is IModularAccount {
         bytes calldata installData,
         bytes[] calldata hooks
     ) internal {
-        ValidationStorage storage _validationStorage =
-            getAccountStorage().validationStorage[ValidationLocatorLib.configToLookupKey(validationConfig)];
+        ValidationStorage storage _validationStorage = getAccountStorage()
+        .validationStorage[ValidationLocatorLib.configToLookupKey(validationConfig)];
 
         _setValidationFunction(_validationStorage, validationConfig, selectors);
 
@@ -160,8 +160,8 @@ abstract contract ModuleManagerInternals is IModularAccount {
         bytes calldata uninstallData,
         bytes[] calldata hookUninstallDatas
     ) internal {
-        ValidationStorage storage _validationStorage =
-            getAccountStorage().validationStorage[ValidationLocatorLib.moduleEntityToLookupKey(validationFunction)];
+        ValidationStorage storage _validationStorage = getAccountStorage()
+        .validationStorage[ValidationLocatorLib.moduleEntityToLookupKey(validationFunction)];
         bool onUninstallSuccess = true;
 
         // Send `onUninstall` to hooks

--- a/src/account/SemiModularAccountBase.sol
+++ b/src/account/SemiModularAccountBase.sol
@@ -246,8 +246,7 @@ abstract contract SemiModularAccountBase is ModularAccountBase {
     /// but the original hash should be passed to the external-facing function for 1271 validation.
     function _replaySafeHash(bytes32 hash) internal view returns (bytes32) {
         return MessageHashUtils.toTypedDataHash({
-            domainSeparator: _domainSeparator(),
-            structHash: _hashStructReplaySafeHash(hash)
+            domainSeparator: _domainSeparator(), structHash: _hashStructReplaySafeHash(hash)
         });
     }
 

--- a/src/factory/AccountFactory.sol
+++ b/src/factory/AccountFactory.sol
@@ -83,12 +83,13 @@ contract AccountFactory is Ownable2Step {
         if (!alreadyDeployed) {
             bytes memory moduleInstallData = abi.encode(entityId, owner);
             // point proxy to actual implementation and init plugins
-            ModularAccount(payable(instance)).initializeWithValidation(
-                ValidationConfigLib.pack(SINGLE_SIGNER_VALIDATION_MODULE, entityId, true, true, true),
-                new bytes4[](0),
-                moduleInstallData,
-                new bytes[](0)
-            );
+            ModularAccount(payable(instance))
+                .initializeWithValidation(
+                    ValidationConfigLib.pack(SINGLE_SIGNER_VALIDATION_MODULE, entityId, true, true, true),
+                    new bytes4[](0),
+                    moduleInstallData,
+                    new bytes[](0)
+                );
             emit ModularAccountDeployed(instance, owner, salt);
         }
 
@@ -142,12 +143,13 @@ contract AccountFactory is Ownable2Step {
         if (!alreadyDeployed) {
             bytes memory moduleInstallData = abi.encode(entityId, ownerX, ownerY);
             // point proxy to actual implementation and init plugins
-            ModularAccount(payable(instance)).initializeWithValidation(
-                ValidationConfigLib.pack(WEBAUTHN_VALIDATION_MODULE, entityId, true, true, true),
-                new bytes4[](0),
-                moduleInstallData,
-                new bytes[](0)
-            );
+            ModularAccount(payable(instance))
+                .initializeWithValidation(
+                    ValidationConfigLib.pack(WEBAUTHN_VALIDATION_MODULE, entityId, true, true, true),
+                    new bytes4[](0),
+                    moduleInstallData,
+                    new bytes[](0)
+                );
             emit WebAuthnModularAccountDeployed(instance, ownerX, ownerY, salt);
         }
 

--- a/src/factory/WebAuthnFactory.sol
+++ b/src/factory/WebAuthnFactory.sol
@@ -85,12 +85,13 @@ contract WebAuthnFactory is Ownable2Step {
         if (!alreadyDeployed) {
             bytes memory moduleInstallData = abi.encode(entityId, ownerX, ownerY);
             // point proxy to actual implementation and init plugins
-            ModularAccount(payable(instance)).initializeWithValidation(
-                ValidationConfigLib.pack(WEBAUTHN_VALIDATION_MODULE, entityId, true, true, true),
-                new bytes4[](0),
-                moduleInstallData,
-                new bytes[](0)
-            );
+            ModularAccount(payable(instance))
+                .initializeWithValidation(
+                    ValidationConfigLib.pack(WEBAUTHN_VALIDATION_MODULE, entityId, true, true, true),
+                    new bytes4[](0),
+                    moduleInstallData,
+                    new bytes[](0)
+                );
             emit WebAuthnModularAccountDeployed(instance, ownerX, ownerY, salt);
         }
 

--- a/src/helpers/ExecutionInstallDelegate.sol
+++ b/src/helpers/ExecutionInstallDelegate.sol
@@ -86,10 +86,7 @@ contract ExecutionInstallDelegate {
             ManifestExecutionHook memory mh = manifest.executionHooks[i];
             LinkedListSet storage executionHooks = _storage.executionStorage[mh.executionSelector].executionHooks;
             HookConfig hookConfig = HookConfigLib.packExecHook({
-                _module: module,
-                _entityId: mh.entityId,
-                _hasPre: mh.isPreHook,
-                _hasPost: mh.isPostHook
+                _module: module, _entityId: mh.entityId, _hasPre: mh.isPreHook, _hasPost: mh.isPostHook
             });
             ModuleInstallCommonsLib.addExecHooks(executionHooks, hookConfig);
         }
@@ -121,10 +118,7 @@ contract ExecutionInstallDelegate {
             ManifestExecutionHook memory mh = manifest.executionHooks[i];
             LinkedListSet storage executionHooks = _storage.executionStorage[mh.executionSelector].executionHooks;
             HookConfig hookConfig = HookConfigLib.packExecHook({
-                _module: module,
-                _entityId: mh.entityId,
-                _hasPre: mh.isPreHook,
-                _hasPost: mh.isPostHook
+                _module: module, _entityId: mh.entityId, _hasPre: mh.isPreHook, _hasPost: mh.isPostHook
             });
             _removeExecHooks(executionHooks, hookConfig);
         }

--- a/src/libraries/ExecutionLib.sol
+++ b/src/libraries/ExecutionLib.sol
@@ -272,27 +272,26 @@ library ExecutionLib {
 
             // Perform the call, reverting on failure or insufficient return data.
 
-            success :=
-                and(
-                    // Yul evaluates expressions from right to left, so `returndatasize` will evaluate after `call`.
-                    gt(returndatasize(), 0x1f),
-                    call(
-                        // If gas is the leftmost item before the call, it *should* be placed immediately before the
-                        // call opcode and be allowed in validation.
-                        gas(),
-                        moduleAddress,
-                        /*value*/
-                        0,
-                        /*argOffset*/
-                        add(buffer, 0x20), // jump over 32 bytes for length
-                        /*argSize*/
-                        actualCallLength,
-                        /*retOffset*/
-                        0,
-                        /*retSize*/
-                        0x20
-                    )
+            success := and(
+                // Yul evaluates expressions from right to left, so `returndatasize` will evaluate after `call`.
+                gt(returndatasize(), 0x1f),
+                call(
+                    // If gas is the leftmost item before the call, it *should* be placed immediately before the
+                    // call opcode and be allowed in validation.
+                    gas(),
+                    moduleAddress,
+                    /*value*/
+                    0,
+                    /*argOffset*/
+                    add(buffer, 0x20), // jump over 32 bytes for length
+                    /*argSize*/
+                    actualCallLength,
+                    /*retOffset*/
+                    0,
+                    /*retSize*/
+                    0x20
                 )
+            )
         }
 
         if (success) {
@@ -386,7 +385,9 @@ library ExecutionLib {
                 mstore(add(authorizationAbsOffset, add(roundedDownAuthorizationLength, 0x20)), 0)
                 // Copy the authorization segment from calldata into the correct location in the buffer.
                 calldatacopy(
-                    add(authorizationAbsOffset, 0x20), authorizationSegment.offset, authorizationSegment.length
+                    add(authorizationAbsOffset, 0x20),
+                    authorizationSegment.offset,
+                    authorizationSegment.length
                 )
             }
 
@@ -405,21 +406,20 @@ library ExecutionLib {
             actualCallLength := add(actualCallLength, and(add(authorizationSegment.length, 0x1f), not(0x1f)))
 
             // Perform the call
-            success :=
-                call(
-                    gas(),
-                    moduleAddress,
-                    /*value*/
-                    0,
-                    /*argOffset*/
-                    add(buffer, 0x40), // jump over 32 bytes for length, and another 32 bytes for the account
-                    /*argSize*/
-                    actualCallLength,
-                    /*retOffset*/
-                    codesize(),
-                    /*retSize*/
-                    0
-                )
+            success := call(
+                gas(),
+                moduleAddress,
+                /*value*/
+                0,
+                /*argOffset*/
+                add(buffer, 0x40), // jump over 32 bytes for length, and another 32 bytes for the account
+                /*argSize*/
+                actualCallLength,
+                /*retOffset*/
+                codesize(),
+                /*retSize*/
+                0
+            )
         }
 
         if (!success) {
@@ -481,7 +481,9 @@ library ExecutionLib {
                 mstore(add(authorizationAbsOffset, add(roundedDownAuthorizationLength, 0x20)), 0)
                 // Copy the authorization segment from calldata into the correct location in the buffer.
                 calldatacopy(
-                    add(authorizationAbsOffset, 0x20), authorizationSegment.offset, authorizationSegment.length
+                    add(authorizationAbsOffset, 0x20),
+                    authorizationSegment.offset,
+                    authorizationSegment.length
                 )
             }
 
@@ -506,21 +508,20 @@ library ExecutionLib {
             if iszero(extcodesize(moduleAddress)) { revert(0, 0) }
 
             // Perform the call
-            success :=
-                call(
-                    gas(),
-                    moduleAddress,
-                    /*value*/
-                    0,
-                    /*argOffset*/
-                    add(buffer, 0x20), // jump over 32 bytes for length
-                    /*argSize*/
-                    actualCallLength,
-                    /*retOffset*/
-                    codesize(),
-                    /*retSize*/
-                    0
-                )
+            success := call(
+                gas(),
+                moduleAddress,
+                /*value*/
+                0,
+                /*argOffset*/
+                add(buffer, 0x20), // jump over 32 bytes for length
+                /*argSize*/
+                actualCallLength,
+                /*retOffset*/
+                codesize(),
+                /*retSize*/
+                0
+            )
         }
 
         if (!success) {
@@ -678,21 +679,20 @@ library ExecutionLib {
             mstore(add(buffer, 0x24), entityId)
 
             // Perform the call, storing the first two words of return data into scratch space.
-            success :=
-                call(
-                    gas(),
-                    moduleAddress,
-                    /*value*/
-                    0,
-                    /*argOffset*/
-                    add(buffer, 0x20), // jump over 32 bytes for length
-                    /*argSize*/
-                    mload(buffer),
-                    /*retOffset*/
-                    0,
-                    /*retSize*/
-                    0x40
-                )
+            success := call(
+                gas(),
+                moduleAddress,
+                /*value*/
+                0,
+                /*argOffset*/
+                add(buffer, 0x20), // jump over 32 bytes for length
+                /*argSize*/
+                mload(buffer),
+                /*retOffset*/
+                0,
+                /*retSize*/
+                0x40
+            )
 
             // Need at least 64 bytes of return data to be considered successful.
             success := and(success, gt(returndatasize(), 0x3f))
@@ -880,21 +880,20 @@ library ExecutionLib {
                 let callLength := sub(segmentLength, 0x1c)
 
                 // Perform the call
-                success :=
-                    call(
-                        gas(),
-                        moduleAddress,
-                        /*value*/
-                        0,
-                        /*argOffset*/
-                        workingMemPtr,
-                        /*argSize*/
-                        callLength,
-                        /*retOffset*/
-                        codesize(),
-                        /*retSize*/
-                        0
-                    )
+                success := call(
+                    gas(),
+                    moduleAddress,
+                    /*value*/
+                    0,
+                    /*argOffset*/
+                    workingMemPtr,
+                    /*argSize*/
+                    callLength,
+                    /*retOffset*/
+                    codesize(),
+                    /*retSize*/
+                    0
+                )
 
                 // Step the working mem pointer back to the previous segment
                 workingMemPtr := sub(segmentStart, 0x20)
@@ -970,19 +969,18 @@ library ExecutionLib {
             let actualCallLength := add(0xa4, and(add(signatureSegment.length, 0x1f), not(0x1f)))
 
             // Perform the call
-            success :=
-                staticcall(
-                    gas(),
-                    moduleAddress,
-                    /*argOffset*/
-                    add(buffer, 0x40), // jump over 32 bytes for length, and another 32 bytes for the account
-                    /*argSize*/
-                    actualCallLength,
-                    /*retOffset*/
-                    0,
-                    /*retSize*/
-                    0x20
-                )
+            success := staticcall(
+                gas(),
+                moduleAddress,
+                /*argOffset*/
+                add(buffer, 0x40), // jump over 32 bytes for length, and another 32 bytes for the account
+                /*argSize*/
+                actualCallLength,
+                /*retOffset*/
+                0,
+                /*retSize*/
+                0x20
+            )
         }
 
         if (!success) {
@@ -1035,24 +1033,23 @@ library ExecutionLib {
             let actualCallLength := add(0xc4, and(add(signatureSegment.length, 0x1f), not(0x1f)))
 
             // Perform the call
-            success :=
-                and(
-                    // Yul evaluates expressions from right to left, so `returndatasize` will evaluate after
-                    // `staticcall`.
-                    gt(returndatasize(), 0x1f),
-                    staticcall(
-                        gas(),
-                        moduleAddress,
-                        /*argOffset*/
-                        add(buffer, 0x20), // jump over 32 bytes for length, and another 32 bytes for the account
-                        /*argSize*/
-                        actualCallLength,
-                        /*retOffset*/
-                        0,
-                        /*retSize*/
-                        0x20
-                    )
+            success := and(
+                // Yul evaluates expressions from right to left, so `returndatasize` will evaluate after
+                // `staticcall`.
+                gt(returndatasize(), 0x1f),
+                staticcall(
+                    gas(),
+                    moduleAddress,
+                    /*argOffset*/
+                    add(buffer, 0x20), // jump over 32 bytes for length, and another 32 bytes for the account
+                    /*argSize*/
+                    actualCallLength,
+                    /*retOffset*/
+                    0,
+                    /*retSize*/
+                    0x20
                 )
+            )
         }
 
         if (success) {

--- a/src/libraries/ValidationLocatorLib.sol
+++ b/src/libraries/ValidationLocatorLib.sol
@@ -229,11 +229,7 @@ library ValidationLocatorLib {
         }
     }
 
-    function directCallLookupKey(address directCallValidation)
-        internal
-        pure
-        returns (ValidationLookupKey result)
-    {
+    function directCallLookupKey(address directCallValidation) internal pure returns (ValidationLookupKey result) {
         result = ValidationLookupKey.wrap(uint168(uint160(directCallValidation)) << 8 | _IS_DIRECT_CALL_VALIDATION);
     }
 

--- a/src/modules/permissions/PaymasterGuardModule.sol
+++ b/src/modules/permissions/PaymasterGuardModule.sol
@@ -75,12 +75,11 @@ contract PaymasterGuardModule is ModuleBase, IValidationHookModule {
     }
 
     /// @inheritdoc IValidationHookModule
+    // solhint-disable no-empty-blocks
     function preRuntimeValidationHook(uint32, address, uint256, bytes calldata, bytes calldata)
         external
         view
         override
-        // solhint-disable-next-line no-empty-blocks
-
     {}
 
     // solhint-disable-next-line no-empty-blocks

--- a/src/modules/permissions/PaymasterGuardModule.sol
+++ b/src/modules/permissions/PaymasterGuardModule.sol
@@ -79,7 +79,8 @@ contract PaymasterGuardModule is ModuleBase, IValidationHookModule {
         external
         view
         override
-    // solhint-disable-next-line no-empty-blocks
+        // solhint-disable-next-line no-empty-blocks
+
     {}
 
     // solhint-disable-next-line no-empty-blocks

--- a/src/modules/permissions/TimeRangeModule.sol
+++ b/src/modules/permissions/TimeRangeModule.sol
@@ -76,9 +76,7 @@ contract TimeRangeModule is IValidationHookModule, ModuleBase {
     {
         TimeRange memory timeRange = timeRanges[entityId][msg.sender];
         return _packValidationData({
-            sigFailed: false,
-            validUntil: timeRange.validUntil,
-            validAfter: timeRange.validAfter
+            sigFailed: false, validUntil: timeRange.validUntil, validAfter: timeRange.validAfter
         });
     }
 

--- a/test/account/AccountExecHooks.t.sol
+++ b/test/account/AccountExecHooks.t.sol
@@ -47,13 +47,12 @@ contract AccountExecHooksTest is AccountTestBase {
         _revertSnapshot = vm.snapshotState();
         _allowTestDirectCalls();
 
-        _m1.executionFunctions.push(
-            ManifestExecutionFunction({
-                executionSelector: _EXEC_SELECTOR,
-                skipRuntimeValidation: true,
-                allowGlobalValidation: false
-            })
-        );
+        _m1.executionFunctions
+            .push(
+                ManifestExecutionFunction({
+                    executionSelector: _EXEC_SELECTOR, skipRuntimeValidation: true, allowGlobalValidation: false
+                })
+            );
     }
 
     function test_preExecHook_install() public withSMATest {
@@ -185,9 +184,7 @@ contract AccountExecHooksTest is AccountTestBase {
 
         // vm.startPrank(owner1);
         account1.installExecution({
-            module: address(mockModule1),
-            manifest: mockModule1.executionManifest(),
-            moduleInstallData: bytes("a")
+            module: address(mockModule1), manifest: mockModule1.executionManifest(), moduleInstallData: bytes("a")
         });
         // vm.stopPrank();
     }

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -96,14 +96,10 @@ contract AccountReturnDataTest is AccountTestBase {
     function test_returnData_executeBatch() public withSMATest {
         Call[] memory calls = new Call[](2);
         calls[0] = Call({
-            target: address(regularResultContract),
-            value: 0,
-            data: abi.encodeCall(RegularResultContract.foo, ())
+            target: address(regularResultContract), value: 0, data: abi.encodeCall(RegularResultContract.foo, ())
         });
         calls[1] = Call({
-            target: address(regularResultContract),
-            value: 0,
-            data: abi.encodeCall(RegularResultContract.bar, ())
+            target: address(regularResultContract), value: 0, data: abi.encodeCall(RegularResultContract.bar, ())
         });
 
         bytes memory retData = account1.executeWithRuntimeValidation(
@@ -129,9 +125,8 @@ contract AccountReturnDataTest is AccountTestBase {
 
     // Tests the ability to read data via executeWithAuthorization
     function test_returnData_authorized_exec() public withSMATest {
-        bool result = ResultConsumerModule(address(account1)).checkResultExecuteWithRuntimeValidation(
-            address(regularResultContract), keccak256("bar")
-        );
+        bool result = ResultConsumerModule(address(account1))
+            .checkResultExecuteWithRuntimeValidation(address(regularResultContract), keccak256("bar"));
 
         assertTrue(result);
     }

--- a/test/account/DeferredAction.t.sol
+++ b/test/account/DeferredAction.t.sol
@@ -127,9 +127,7 @@ contract DeferredActionTest is AccountTestBase {
         ExecutionManifest memory m;
         m.executionFunctions = new ManifestExecutionFunction[](1);
         m.executionFunctions[0] = ManifestExecutionFunction({
-            executionSelector: newFunctionSelector,
-            skipRuntimeValidation: false,
-            allowGlobalValidation: false
+            executionSelector: newFunctionSelector, skipRuntimeValidation: false, allowGlobalValidation: false
         });
 
         vm.prank(address(account1));
@@ -246,9 +244,7 @@ contract DeferredActionTest is AccountTestBase {
 
         Call[] memory outerCalls = new Call[](1);
         outerCalls[0] = Call({
-            target: address(account1),
-            value: 0,
-            data: abi.encodeCall(IModularAccount.executeBatch, (innerCalls))
+            target: address(account1), value: 0, data: abi.encodeCall(IModularAccount.executeBatch, (innerCalls))
         });
 
         bytes memory deferredAction = abi.encodeCall(IModularAccount.executeBatch, (outerCalls));

--- a/test/account/DeferredValidation.t.sol
+++ b/test/account/DeferredValidation.t.sol
@@ -316,7 +316,9 @@ contract DeferredValidationTest is AccountTestBase {
         // Install a validation-associated execution hook to the outer validation.
         bytes[] memory hooks = new bytes[](1);
         hooks[0] = abi.encodePacked(
-            HookConfigLib.packExecHook({_module: address(hookModule), _entityId: 0, _hasPre: true, _hasPost: true}),
+            HookConfigLib.packExecHook({
+                _module: address(hookModule), _entityId: 0, _hasPre: true, _hasPost: true
+            }),
             "" // onInstall data
         );
         vm.prank(address(entryPoint));

--- a/test/account/GlobalValidationTest.t.sol
+++ b/test/account/GlobalValidationTest.t.sol
@@ -59,7 +59,8 @@ contract GlobalValidationTest is AccountTestBase {
             sender: address(account2),
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: abi.encodePacked(
-                address(factory), abi.encodeCall(factory.createAccount, (owner2, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID))
+                address(factory),
+                abi.encodeCall(factory.createAccount, (owner2, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID))
             ),
             callData: abi.encodeCall(ModularAccountBase.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
@@ -120,7 +121,8 @@ contract GlobalValidationTest is AccountTestBase {
             sender: address(account2),
             nonce: _encodeNonce(_signerValidation, SELECTOR_ASSOCIATED_V, 0),
             initCode: abi.encodePacked(
-                address(factory), abi.encodeCall(factory.createAccount, (owner2, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID))
+                address(factory),
+                abi.encodeCall(factory.createAccount, (owner2, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID))
             ),
             callData: abi.encodeCall(ModularAccountBase.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),

--- a/test/account/HookOrdering.t.sol
+++ b/test/account/HookOrdering.t.sol
@@ -254,7 +254,8 @@ contract HookOrderingTest is AccountTestBase {
             nonce: _encodeNonce(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_V, 0),
             initCode: hex"",
             callData: abi.encodeCall(
-                account1.execute, (address(hookOrderChecker), 0 wei, abi.encodeCall(HookOrderCheckerModule.foo, (17)))
+                account1.execute,
+                (address(hookOrderChecker), 0 wei, abi.encodeCall(HookOrderCheckerModule.foo, (17)))
             ),
             accountGasLimits: _encodeGas(1_000_000, 1_000_000),
             preVerificationGas: 0,
@@ -381,50 +382,32 @@ contract HookOrderingTest is AccountTestBase {
         // Validation-associated exec hooks
         hooks[3] = abi.encodePacked(
             HookConfigLib.packExecHook({
-                _module: address(hookOrderChecker),
-                _entityId: 5,
-                _hasPre: true,
-                _hasPost: false
+                _module: address(hookOrderChecker), _entityId: 5, _hasPre: true, _hasPost: false
             })
         );
         hooks[4] = abi.encodePacked(
             HookConfigLib.packExecHook({
-                _module: address(hookOrderChecker),
-                _entityId: 6,
-                _hasPre: false,
-                _hasPost: true
+                _module: address(hookOrderChecker), _entityId: 6, _hasPre: false, _hasPost: true
             })
         );
         hooks[5] = abi.encodePacked(
             HookConfigLib.packExecHook({
-                _module: address(hookOrderChecker),
-                _entityId: 7,
-                _hasPre: true,
-                _hasPost: true
+                _module: address(hookOrderChecker), _entityId: 7, _hasPre: true, _hasPost: true
             })
         );
         hooks[6] = abi.encodePacked(
             HookConfigLib.packExecHook({
-                _module: address(hookOrderChecker),
-                _entityId: 8,
-                _hasPre: true,
-                _hasPost: true
+                _module: address(hookOrderChecker), _entityId: 8, _hasPre: true, _hasPost: true
             })
         );
         hooks[7] = abi.encodePacked(
             HookConfigLib.packExecHook({
-                _module: address(hookOrderChecker),
-                _entityId: 9,
-                _hasPre: true,
-                _hasPost: false
+                _module: address(hookOrderChecker), _entityId: 9, _hasPre: true, _hasPost: false
             })
         );
         hooks[8] = abi.encodePacked(
             HookConfigLib.packExecHook({
-                _module: address(hookOrderChecker),
-                _entityId: 10,
-                _hasPre: false,
-                _hasPost: true
+                _module: address(hookOrderChecker), _entityId: 10, _hasPre: false, _hasPost: true
             })
         );
 
@@ -467,16 +450,10 @@ contract HookOrderingTest is AccountTestBase {
             isPostHook: true
         });
         execHooks[2] = ManifestExecutionHook({
-            executionSelector: HookOrderCheckerModule.foo.selector,
-            entityId: 13,
-            isPreHook: true,
-            isPostHook: true
+            executionSelector: HookOrderCheckerModule.foo.selector, entityId: 13, isPreHook: true, isPostHook: true
         });
         execHooks[3] = ManifestExecutionHook({
-            executionSelector: HookOrderCheckerModule.foo.selector,
-            entityId: 14,
-            isPreHook: true,
-            isPostHook: true
+            executionSelector: HookOrderCheckerModule.foo.selector, entityId: 14, isPreHook: true, isPostHook: true
         });
         execHooks[4] = ManifestExecutionHook({
             executionSelector: HookOrderCheckerModule.foo.selector,
@@ -493,40 +470,22 @@ contract HookOrderingTest is AccountTestBase {
 
         // Apply hooks to the `execute` function
         execHooks[6] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector,
-            entityId: 11,
-            isPreHook: true,
-            isPostHook: false
+            executionSelector: account1.execute.selector, entityId: 11, isPreHook: true, isPostHook: false
         });
         execHooks[7] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector,
-            entityId: 12,
-            isPreHook: false,
-            isPostHook: true
+            executionSelector: account1.execute.selector, entityId: 12, isPreHook: false, isPostHook: true
         });
         execHooks[8] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector,
-            entityId: 13,
-            isPreHook: true,
-            isPostHook: true
+            executionSelector: account1.execute.selector, entityId: 13, isPreHook: true, isPostHook: true
         });
         execHooks[9] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector,
-            entityId: 14,
-            isPreHook: true,
-            isPostHook: true
+            executionSelector: account1.execute.selector, entityId: 14, isPreHook: true, isPostHook: true
         });
         execHooks[10] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector,
-            entityId: 15,
-            isPreHook: true,
-            isPostHook: false
+            executionSelector: account1.execute.selector, entityId: 15, isPreHook: true, isPostHook: false
         });
         execHooks[11] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector,
-            entityId: 16,
-            isPreHook: false,
-            isPostHook: true
+            executionSelector: account1.execute.selector, entityId: 16, isPreHook: false, isPostHook: true
         });
 
         manifest.executionHooks = execHooks;

--- a/test/account/ModularAccount.t.sol
+++ b/test/account/ModularAccount.t.sol
@@ -124,7 +124,9 @@ contract ModularAccountTest is AccountTestBase {
 
     function test_basicUserOp_withInitCode() public withSMATest {
         bytes memory callData = _isSMATest
-            ? abi.encodeCall(SemiModularAccountBytecode(payable(account1)).updateFallbackSignerData, (owner2, false))
+            ? abi.encodeCall(
+                SemiModularAccountBytecode(payable(account1)).updateFallbackSignerData, (owner2, false)
+            )
             : abi.encodeCall(
                 ModularAccountBase.execute,
                 (
@@ -139,7 +141,8 @@ contract ModularAccountTest is AccountTestBase {
         bytes memory initCode = _isSMATest
             ? abi.encodePacked(address(factory), abi.encodeCall(factory.createSemiModularAccount, (owner2, 0)))
             : abi.encodePacked(
-                address(factory), abi.encodeCall(factory.createAccount, (owner2, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID))
+                address(factory),
+                abi.encodeCall(factory.createAccount, (owner2, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID))
             );
 
         PackedUserOperation memory userOp = PackedUserOperation({
@@ -169,7 +172,8 @@ contract ModularAccountTest is AccountTestBase {
         bytes memory initCode = _isSMATest
             ? abi.encodePacked(address(factory), abi.encodeCall(factory.createSemiModularAccount, (owner2, 0)))
             : abi.encodePacked(
-                address(factory), abi.encodeCall(factory.createAccount, (owner2, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID))
+                address(factory),
+                abi.encodeCall(factory.createAccount, (owner2, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID))
             );
 
         address payable recipient = payable(makeAddr("recipient"));
@@ -367,17 +371,13 @@ contract ModularAccountTest is AccountTestBase {
 
         ComprehensiveModule module = new ComprehensiveModule();
         account1.installExecution({
-            module: address(module),
-            manifest: module.executionManifest(),
-            moduleInstallData: ""
+            module: address(module), manifest: module.executionManifest(), moduleInstallData: ""
         });
 
         vm.expectEmit(true, true, true, true);
         emit ExecutionUninstalled(address(module), true, module.executionManifest());
         account1.uninstallExecution({
-            module: address(module),
-            manifest: module.executionManifest(),
-            moduleUninstallData: ""
+            module: address(module), manifest: module.executionManifest(), moduleUninstallData: ""
         });
 
         ExecutionDataView memory data = account1.getExecutionData(module.foo.selector);
@@ -391,9 +391,7 @@ contract ModularAccountTest is AccountTestBase {
         module = new MockModule(_manifest);
 
         account1.installExecution({
-            module: address(module),
-            manifest: module.executionManifest(),
-            moduleInstallData: ""
+            module: address(module), manifest: module.executionManifest(), moduleInstallData: ""
         });
 
         vm.stopPrank();
@@ -510,7 +508,9 @@ contract ModularAccountTest is AccountTestBase {
 
         PackedUserOperation memory userOp = PackedUserOperation({
             sender: address(account1),
-            nonce: _encodeNonce(ModuleEntityLib.pack(address(singleSignerValidationModule), newEntityId), GLOBAL_V, 0),
+            nonce: _encodeNonce(
+                ModuleEntityLib.pack(address(singleSignerValidationModule), newEntityId), GLOBAL_V, 0
+            ),
             initCode: "",
             callData: abi.encodeCall(ModularAccountBase.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
@@ -685,10 +685,7 @@ contract ModularAccountTest is AccountTestBase {
         ExecutionManifest memory m;
         m.executionHooks = new ManifestExecutionHook[](1);
         m.executionHooks[0] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector,
-            entityId: 0,
-            isPreHook: true,
-            isPostHook: false
+            executionSelector: account1.execute.selector, entityId: 0, isPreHook: true, isPostHook: false
         });
 
         vm.prank(address(entryPoint));

--- a/test/account/PHCallBuffers.t.sol
+++ b/test/account/PHCallBuffers.t.sol
@@ -497,10 +497,7 @@ contract PHCallBufferTest is AccountTestBase {
         for (uint256 i = 0; i < 3; i++) {
             hooks[i] = abi.encodePacked(
                 HookConfigLib.packExecHook({
-                    _module: address(execHooks[i]),
-                    _entityId: uint32(i),
-                    _hasPre: true,
-                    _hasPost: false
+                    _module: address(execHooks[i]), _entityId: uint32(i), _hasPre: true, _hasPost: false
                 })
             );
         }
@@ -527,10 +524,7 @@ contract PHCallBufferTest is AccountTestBase {
         }
 
         account1.installValidation({
-            validationConfig: validationConfig,
-            selectors: new bytes4[](0),
-            installData: "",
-            hooks: hooks
+            validationConfig: validationConfig, selectors: new bytes4[](0), installData: "", hooks: hooks
         });
 
         _validationFunction = ValidationConfigLib.moduleEntity(validationConfig);
@@ -562,8 +556,9 @@ contract PHCallBufferTest is AccountTestBase {
         preValidationHook = new MockModule(m);
 
         bytes[] memory hooks = new bytes[](1);
-        hooks[0] =
-            abi.encodePacked(HookConfigLib.packValidationHook({_module: address(preValidationHook), _entityId: 1}));
+        hooks[0] = abi.encodePacked(
+            HookConfigLib.packValidationHook({_module: address(preValidationHook), _entityId: 1})
+        );
 
         account1.installValidation({
             validationConfig: ValidationConfigLib.pack({

--- a/test/account/PerHookData.t.sol
+++ b/test/account/PerHookData.t.sol
@@ -83,8 +83,7 @@ contract PerHookDataTest is CustomValidationTestBase {
 
         PreValidationHookData[] memory preValidationHookData = new PreValidationHookData[](1);
         preValidationHookData[0] = PreValidationHookData({
-            index: 0,
-            validationData: abi.encodePacked(address(0x1234123412341234123412341234123412341234))
+            index: 0, validationData: abi.encodePacked(address(0x1234123412341234123412341234123412341234))
         });
 
         userOp.signature = _encodeSignature(
@@ -288,8 +287,7 @@ contract PerHookDataTest is CustomValidationTestBase {
     function test_failAccessControl_badSigData_runtime() public withSMATest {
         PreValidationHookData[] memory preValidationHookData = new PreValidationHookData[](1);
         preValidationHookData[0] = PreValidationHookData({
-            index: 0,
-            validationData: abi.encodePacked(address(0x1234123412341234123412341234123412341234))
+            index: 0, validationData: abi.encodePacked(address(0x1234123412341234123412341234123412341234))
         });
 
         vm.prank(owner1);
@@ -443,8 +441,7 @@ contract PerHookDataTest is CustomValidationTestBase {
 
         PreValidationHookData[] memory preValidationHookData = new PreValidationHookData[](1);
         preValidationHookData[0] = PreValidationHookData({
-            index: 0,
-            validationData: abi.encodePacked(address(0x1234123412341234123412341234123412341234))
+            index: 0, validationData: abi.encodePacked(address(0x1234123412341234123412341234123412341234))
         });
 
         vm.expectRevert(
@@ -527,8 +524,15 @@ contract PerHookDataTest is CustomValidationTestBase {
         );
         // patched to work during SMA tests by enforcing that the new validation is not the fallback validation.
         _signerValidation = ModuleEntityLib.pack(address(singleSignerValidationModule), _VALIDATION_ENTITY_ID);
-        return (
-            _signerValidation, true, true, true, new bytes4[](0), abi.encode(_VALIDATION_ENTITY_ID, owner1), hooks
-        );
+        return
+            (
+                _signerValidation,
+                true,
+                true,
+                true,
+                new bytes4[](0),
+                abi.encode(_VALIDATION_ENTITY_ID, owner1),
+                hooks
+            );
     }
 }

--- a/test/account/ReplaceModule.t.sol
+++ b/test/account/ReplaceModule.t.sol
@@ -24,7 +24,9 @@ import {
     ManifestExecutionHook
 } from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 import {
-    Call, IModularAccount, ModuleEntity
+    Call,
+    IModularAccount,
+    ModuleEntity
 } from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
 import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
@@ -185,7 +187,8 @@ contract UpgradeModuleTest is AccountTestBase {
             target: address(account1),
             value: 0,
             data: abi.encodeCall(
-                IModularAccount.uninstallValidation, (currModuleEntity, abi.encode(validationEntityId1), emptyBytesArr)
+                IModularAccount.uninstallValidation,
+                (currModuleEntity, abi.encode(validationEntityId1), emptyBytesArr)
             )
         });
         calls[1] = Call({

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -190,8 +190,9 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         calls[0] = Call(address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()));
         calls[1] = Call(address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()));
 
-        PackedUserOperation memory userOp =
-            _generateUserOpWithComprehensiveModuleValidation(abi.encodeCall(IModularAccount.executeBatch, (calls)));
+        PackedUserOperation memory userOp = _generateUserOpWithComprehensiveModuleValidation(
+            abi.encodeCall(IModularAccount.executeBatch, (calls))
+        );
 
         PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
         userOps[0] = userOp;

--- a/test/account/SigCallBuffer.t.sol
+++ b/test/account/SigCallBuffer.t.sol
@@ -103,7 +103,7 @@ contract SigCallBufferTest is AccountTestBase {
         fuzzConfig.preValidationHookData[1] = hex"";
         fuzzConfig.preValidationHookData[2] = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
         fuzzConfig.preValidationHookData[3] =
-            hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffabcd";
+        hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffabcd";
 
         _setUp4ValidationHooks();
 
@@ -193,8 +193,8 @@ contract SigCallBufferTest is AccountTestBase {
             // validation hooks at different addresses
             validationHooks[i] = new MockModule{salt: keccak256(abi.encode(i, _isSMATest))}(m);
             // These modules emit events, but signature validation happens as a staticcall, so we can't expect the
-            // events. Instead, we mock all of the calls coming into these contracts, and expect calls to them. They
-            // are also re-deployed for the SMA test, so the tests should be distinct.
+            // events. Instead, we mock all of the calls coming into these contracts, and expect calls to them.
+            // They are also re-deployed for the SMA test, so the tests should be distinct.
             vm.mockCall(address(validationHooks[i]), "", "");
 
             hooks[i] =

--- a/test/account/UOCallBuffer.t.sol
+++ b/test/account/UOCallBuffer.t.sol
@@ -58,7 +58,7 @@ contract UOCallBufferTest is AccountTestBase {
             gasFees: _encodeGas(1, 2),
             paymasterAndData: "",
             signature: "" // keep the signature empty for now, because each individual hook receives no data in
-                // this test.
+            // this test.
         });
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
 
@@ -101,7 +101,7 @@ contract UOCallBufferTest is AccountTestBase {
             gasFees: _encodeGas(1, 2),
             paymasterAndData: "",
             signature: "" // keep the signature empty for now, because each individual hook receives no data in
-                // this test.
+            // this test.
         });
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);
 
@@ -186,7 +186,7 @@ contract UOCallBufferTest is AccountTestBase {
             gasFees: _encodeGas(1, 2),
             paymasterAndData: "",
             signature: "" // keep the signature empty for now, because each individual hook receives separate data
-                // in this test.
+            // in this test.
         });
 
         bytes32 userOpHash = entryPoint.getUserOpHash(userOp);

--- a/test/account/UpgradeToSma.t.sol
+++ b/test/account/UpgradeToSma.t.sol
@@ -115,9 +115,8 @@ contract UpgradeToSmaTest is AccountTestBase {
 
         // Upgrade the LightAccount to an SMA-Storage and call the initializer.
         vm.prank(address(entryPoint));
-        ModularAccount(newAccount).upgradeToAndCall(
-            smaStorageImpl, abi.encodeCall(SemiModularAccountStorageOnly.initialize, owner2)
-        );
+        ModularAccount(newAccount)
+            .upgradeToAndCall(smaStorageImpl, abi.encodeCall(SemiModularAccountStorageOnly.initialize, owner2));
 
         // Build expected revert data for a UO with the original signer.
         bytes memory expectedRevertdata =

--- a/test/account/ValidationAssocHooks.t.sol
+++ b/test/account/ValidationAssocHooks.t.sol
@@ -74,10 +74,7 @@ contract ValidationAssocHooksTest is AccountTestBase {
         for (uint256 i = 0; i < 257; i++) {
             hookInstalls[i] = abi.encodePacked(
                 HookConfigLib.packExecHook({
-                    _module: address(hooks[i]),
-                    _entityId: uint32(i),
-                    _hasPre: false,
-                    _hasPost: false
+                    _module: address(hooks[i]), _entityId: uint32(i), _hasPre: false, _hasPost: false
                 })
             );
         }

--- a/test/account/ValidationIntersection.t.sol
+++ b/test/account/ValidationIntersection.t.sol
@@ -204,7 +204,7 @@ contract ValidationIntersectionTest is AccountTestBase {
         oneHookModule.setValidationData(
             0, // returns OK
             uint256(uint160(badAuthorizer)) // returns an aggregator, which preValidation hooks are not allowed to
-                // do.
+            // do.
         );
 
         PackedUserOperation memory userOp;

--- a/test/libraries/LinkedListSetLib.t.sol
+++ b/test/libraries/LinkedListSetLib.t.sol
@@ -19,9 +19,7 @@ pragma solidity ^0.8.26;
 
 import {Test} from "forge-std/Test.sol";
 
-import {
-    LinkedListSet, LinkedListSetLib, SENTINEL_VALUE, SetValue
-} from "../../src/libraries/LinkedListSetLib.sol";
+import {LinkedListSet, LinkedListSetLib, SENTINEL_VALUE, SetValue} from "../../src/libraries/LinkedListSetLib.sol";
 
 // Ported over from test/AssociatedLinkedListSetLib.t.sol, dropping test_no_address_collision
 contract LinkedListSetLibTest is Test {

--- a/test/mocks/modules/ComprehensiveModule.sol
+++ b/test/mocks/modules/ComprehensiveModule.sol
@@ -159,9 +159,7 @@ contract ComprehensiveModule is
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
         manifest.executionFunctions[0] = ManifestExecutionFunction({
-            executionSelector: this.foo.selector,
-            skipRuntimeValidation: false,
-            allowGlobalValidation: false
+            executionSelector: this.foo.selector, skipRuntimeValidation: false, allowGlobalValidation: false
         });
 
         manifest.executionHooks = new ManifestExecutionHook[](3);

--- a/test/mocks/modules/HookOrderCheckerModule.sol
+++ b/test/mocks/modules/HookOrderCheckerModule.sol
@@ -50,9 +50,7 @@ contract HookOrderCheckerModule is
         return 0;
     }
 
-    function validateRuntime(address, uint32 entityId, address, uint256, bytes calldata, bytes calldata)
-        external
-    {
+    function validateRuntime(address, uint32 entityId, address, uint256, bytes calldata, bytes calldata) external {
         recordedFunctionCalls.push(uint256(entityId));
     }
 
@@ -75,9 +73,7 @@ contract HookOrderCheckerModule is
         return 0;
     }
 
-    function preRuntimeValidationHook(uint32 entityId, address, uint256, bytes calldata, bytes calldata)
-        external
-    {
+    function preRuntimeValidationHook(uint32 entityId, address, uint256, bytes calldata, bytes calldata) external {
         recordedFunctionCalls.push(uint256(entityId));
     }
 
@@ -116,9 +112,7 @@ contract HookOrderCheckerModule is
     function executionManifest() external pure returns (ExecutionManifest memory) {
         ManifestExecutionFunction[] memory executionFunctions = new ManifestExecutionFunction[](1);
         executionFunctions[0] = ManifestExecutionFunction({
-            executionSelector: this.foo.selector,
-            skipRuntimeValidation: false,
-            allowGlobalValidation: false
+            executionSelector: this.foo.selector, skipRuntimeValidation: false, allowGlobalValidation: false
         });
 
         return ExecutionManifest({

--- a/test/mocks/modules/MockExecutionInstallationModule.sol
+++ b/test/mocks/modules/MockExecutionInstallationModule.sol
@@ -22,7 +22,8 @@ import {
     ManifestExecutionFunction
 } from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 import {
-    ExecutionManifest, IExecutionModule
+    ExecutionManifest,
+    IExecutionModule
 } from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 import {IModule} from "@erc6900/reference-implementation/interfaces/IModule.sol";
 

--- a/test/mocks/modules/ReturnDataModuleMocks.sol
+++ b/test/mocks/modules/ReturnDataModuleMocks.sol
@@ -59,14 +59,10 @@ contract ResultCreatorModule is IExecutionModule, ModuleBase {
 
         manifest.executionFunctions = new ManifestExecutionFunction[](2);
         manifest.executionFunctions[0] = ManifestExecutionFunction({
-            executionSelector: this.foo.selector,
-            skipRuntimeValidation: true,
-            allowGlobalValidation: false
+            executionSelector: this.foo.selector, skipRuntimeValidation: true, allowGlobalValidation: false
         });
         manifest.executionFunctions[1] = ManifestExecutionFunction({
-            executionSelector: this.bar.selector,
-            skipRuntimeValidation: false,
-            allowGlobalValidation: false
+            executionSelector: this.bar.selector, skipRuntimeValidation: false, allowGlobalValidation: false
         });
 
         return manifest;
@@ -119,10 +115,15 @@ contract ResultConsumerModule is IExecutionModule, ModuleBase, IValidationModule
     // Check the return data through the execute with authorization case
     function checkResultExecuteWithRuntimeValidation(address target, bytes32 expected) external returns (bool) {
         // This result should be allowed based on the manifest permission request
-        bytes memory returnData = IModularAccount(msg.sender).executeWithRuntimeValidation(
-            abi.encodeCall(IModularAccount.execute, (target, 0, abi.encodeCall(RegularResultContract.foo, ()))),
-            _encodeSignature(ModuleEntityLib.pack(address(this), DIRECT_CALL_VALIDATION_ENTITY_ID), uint8(0), "")
-        );
+        bytes memory returnData = IModularAccount(msg.sender)
+            .executeWithRuntimeValidation(
+                abi.encodeCall(
+                    IModularAccount.execute, (target, 0, abi.encodeCall(RegularResultContract.foo, ()))
+                ),
+                _encodeSignature(
+                        ModuleEntityLib.pack(address(this), DIRECT_CALL_VALIDATION_ENTITY_ID), uint8(0), ""
+                    )
+            );
 
         bytes32 actual = abi.decode(abi.decode(returnData, (bytes)), (bytes32));
 

--- a/test/mocks/modules/ValidationModuleMocks.sol
+++ b/test/mocks/modules/ValidationModuleMocks.sol
@@ -129,9 +129,7 @@ contract MockUserOpValidationModule is MockBaseUserOpValidationModule {
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
         manifest.executionFunctions[0] = ManifestExecutionFunction({
-            executionSelector: this.foo.selector,
-            skipRuntimeValidation: false,
-            allowGlobalValidation: false
+            executionSelector: this.foo.selector, skipRuntimeValidation: false, allowGlobalValidation: false
         });
 
         return manifest;
@@ -161,9 +159,7 @@ contract MockUserOpValidation1HookModule is MockBaseUserOpValidationModule {
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
         manifest.executionFunctions[0] = ManifestExecutionFunction({
-            executionSelector: this.bar.selector,
-            skipRuntimeValidation: false,
-            allowGlobalValidation: false
+            executionSelector: this.bar.selector, skipRuntimeValidation: false, allowGlobalValidation: false
         });
 
         return manifest;
@@ -196,9 +192,7 @@ contract MockUserOpValidation2HookModule is MockBaseUserOpValidationModule {
 
         manifest.executionFunctions = new ManifestExecutionFunction[](1);
         manifest.executionFunctions[0] = ManifestExecutionFunction({
-            executionSelector: this.baz.selector,
-            skipRuntimeValidation: false,
-            allowGlobalValidation: false
+            executionSelector: this.baz.selector, skipRuntimeValidation: false, allowGlobalValidation: false
         });
 
         return manifest;

--- a/test/modules/AllowlistERC20TokenLimit.t.sol
+++ b/test/modules/AllowlistERC20TokenLimit.t.sol
@@ -67,10 +67,7 @@ contract AllowlistERC20TokenLimitTest is AccountTestBase {
         bytes[] memory hooks = new bytes[](1);
         hooks[0] = abi.encodePacked(
             HookConfigLib.packExecHook({
-                _module: address(module),
-                _entityId: ENTITY_ID,
-                _hasPre: true,
-                _hasPost: false
+                _module: address(module), _entityId: ENTITY_ID, _hasPre: true, _hasPost: false
             }),
             abi.encode(ENTITY_ID, inputs)
         );
@@ -131,9 +128,7 @@ contract AllowlistERC20TokenLimitTest is AccountTestBase {
         calls[1] =
             Call({target: address(erc20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient, 1 ether))});
         calls[2] = Call({
-            target: address(erc20),
-            value: 0,
-            data: abi.encodeCall(IERC20.transfer, (recipient, 5 ether + 100_000))
+            target: address(erc20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient, 5 ether + 100_000))
         });
 
         vm.startPrank(address(entryPoint));
@@ -151,9 +146,7 @@ contract AllowlistERC20TokenLimitTest is AccountTestBase {
         calls[1] =
             Call({target: address(erc20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient, 1 ether))});
         calls[2] = Call({
-            target: address(erc20),
-            value: 0,
-            data: abi.encodeCall(IERC20.approve, (recipient, 5 ether + 100_000))
+            target: address(erc20), value: 0, data: abi.encodeCall(IERC20.approve, (recipient, 5 ether + 100_000))
         });
 
         vm.startPrank(address(entryPoint));
@@ -171,9 +164,7 @@ contract AllowlistERC20TokenLimitTest is AccountTestBase {
         calls[1] =
             Call({target: address(erc20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient, 1 ether))});
         calls[2] = Call({
-            target: address(erc20),
-            value: 0,
-            data: abi.encodeCall(IERC20.approve, (recipient, 9 ether + 100_000))
+            target: address(erc20), value: 0, data: abi.encodeCall(IERC20.approve, (recipient, 9 ether + 100_000))
         });
 
         vm.startPrank(address(entryPoint));
@@ -203,9 +194,7 @@ contract AllowlistERC20TokenLimitTest is AccountTestBase {
         calls[1] =
             Call({target: address(erc20), value: 0, data: abi.encodeCall(IERC20.transfer, (recipient, 1 ether))});
         calls[2] = Call({
-            target: address(erc20),
-            value: 0,
-            data: abi.encodeCall(IERC20.approve, (recipient, 5 ether + 100_000))
+            target: address(erc20), value: 0, data: abi.encodeCall(IERC20.approve, (recipient, 5 ether + 100_000))
         });
         account1.executeWithRuntimeValidation(
             abi.encodeCall(IModularAccount.executeBatch, (calls)), _encodeSignature(validationFunction, 1, "")

--- a/test/modules/NativeTokenLimitModule.t.sol
+++ b/test/modules/NativeTokenLimitModule.t.sol
@@ -19,7 +19,9 @@ pragma solidity ^0.8.26;
 
 import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
 import {
-    Call, IModularAccount, ModuleEntity
+    Call,
+    IModularAccount,
+    ModuleEntity
 } from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {Call, IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
@@ -61,10 +63,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
 
         hooks[1] = abi.encodePacked(
             HookConfigLib.packExecHook({
-                _module: address(module),
-                _entityId: entityId,
-                _hasPre: true,
-                _hasPost: false
+                _module: address(module), _entityId: entityId, _hasPre: true, _hasPost: false
             }),
             abi.encode(entityId, spendLimit)
         );
@@ -91,9 +90,10 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
     }
 
     function _getPerformCreate2Calldata(uint256 value, bytes32 salt) internal pure returns (bytes memory) {
-        return abi.encodeCall(
-            ModularAccountBase.performCreate, (value, type(MockDeployment).creationCode, true, salt)
-        );
+        return
+            abi.encodeCall(
+                ModularAccountBase.performCreate, (value, type(MockDeployment).creationCode, true, salt)
+            );
     }
 
     function _getPackedUO(uint256 gas1, uint256 gas2, uint256 gas3, uint256 gasPrice, bytes memory callData)
@@ -384,10 +384,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
 
         hooks[1] = abi.encodePacked(
             HookConfigLib.packExecHook({
-                _module: address(module),
-                _entityId: entityId,
-                _hasPre: true,
-                _hasPost: false
+                _module: address(module), _entityId: entityId, _hasPre: true, _hasPost: false
             }),
             abi.encode(newEntityId, spendLimit)
         );

--- a/test/modules/PaymasterGuardModule.t.sol
+++ b/test/modules/PaymasterGuardModule.t.sol
@@ -152,7 +152,9 @@ contract PaymasterGuardModuleTest is AccountTestBase {
     {
         return PackedUserOperation({
             sender: accountAddr,
-            nonce: _encodeNonce(ModuleEntityLib.pack(address(singleSignerValidationModule), ENTITY_ID), GLOBAL_V, 0),
+            nonce: _encodeNonce(
+                ModuleEntityLib.pack(address(singleSignerValidationModule), ENTITY_ID), GLOBAL_V, 0
+            ),
             initCode: "",
             callData: abi.encodePacked(
                 ModularAccountBase.executeUserOp.selector, abi.encodeCall(account1.execute, (owner1, 0, hex""))

--- a/test/modules/TimeRangeModule.t.sol
+++ b/test/modules/TimeRangeModule.t.sol
@@ -19,7 +19,8 @@ pragma solidity ^0.8.26;
 
 import {ModuleEntity, ValidationFlags} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {
-    HookConfig, ValidationDataView
+    HookConfig,
+    ValidationDataView
 } from "@erc6900/reference-implementation/interfaces/IModularAccountView.sol";
 import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";

--- a/test/modules/WebAuthnValidationModule.t.sol
+++ b/test/modules/WebAuthnValidationModule.t.sol
@@ -51,12 +51,13 @@ contract WebAuthnValidationModuleTest is AccountTestBase {
         module = new WebAuthnValidationModule();
         account = payable(account1);
         vm.prank(address(entryPoint));
-        ModularAccount(account).installValidation(
-            ValidationConfigLib.pack(address(module), entityId, true, true, true),
-            new bytes4[](0),
-            abi.encode(entityId, x, y),
-            new bytes[](0)
-        );
+        ModularAccount(account)
+            .installValidation(
+                ValidationConfigLib.pack(address(module), entityId, true, true, true),
+                new bytes4[](0),
+                abi.encode(entityId, x, y),
+                new bytes[](0)
+            );
     }
 
     function test_isValidSignature() external view {

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -19,7 +19,9 @@ pragma solidity ^0.8.26;
 
 import {DIRECT_CALL_VALIDATION_ENTITY_ID} from "@erc6900/reference-implementation/helpers/Constants.sol";
 import {
-    Call, IModularAccount, ModuleEntity
+    Call,
+    IModularAccount,
+    ModuleEntity
 } from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {
@@ -43,8 +45,9 @@ import {WebAuthnValidationModule} from "../../src/modules/validation/WebAuthnVal
 
 import {ModuleSignatureUtils} from "./ModuleSignatureUtils.sol";
 import {OptimizedTest} from "./OptimizedTest.sol";
-import {TEST_DEFAULT_VALIDATION_ENTITY_ID as EXT_CONST_TEST_DEFAULT_VALIDATION_ENTITY_ID} from
-    "./TestConstants.sol";
+import {
+    TEST_DEFAULT_VALIDATION_ENTITY_ID as EXT_CONST_TEST_DEFAULT_VALIDATION_ENTITY_ID
+} from "./TestConstants.sol";
 
 /// @dev This contract handles common boilerplate setup for tests using ModularAccount with
 /// SingleSignerValidationModule.
@@ -247,9 +250,7 @@ abstract contract AccountTestBase is OptimizedTest, ModuleSignatureUtils {
         _runtimeCall(abi.encodeCall(IModularAccount.execute, (target, 0, callData)), expectedRevertData);
     }
 
-    function _runtimeExecExpFail(address target, bytes memory callData, bytes memory expectedRevertData)
-        internal
-    {
+    function _runtimeExecExpFail(address target, bytes memory callData, bytes memory expectedRevertData) internal {
         _runtimeCallExpFail(abi.encodeCall(IModularAccount.execute, (target, 0, callData)), expectedRevertData);
     }
 

--- a/test/utils/ModuleSignatureUtils.sol
+++ b/test/utils/ModuleSignatureUtils.sol
@@ -224,8 +224,7 @@ contract ModuleSignatureUtils {
 
     function _getSMAReplaySafeHash(address account, bytes32 digest) internal view returns (bytes32) {
         return MessageHashUtils.toTypedDataHash({
-            domainSeparator: _computeDomainSeparator(account),
-            structHash: _hashStruct(digest)
+            domainSeparator: _computeDomainSeparator(account), structHash: _hashStruct(digest)
         });
     }
 

--- a/test/utils/OptimizedTest.sol
+++ b/test/utils/OptimizedTest.sol
@@ -53,12 +53,10 @@ abstract contract OptimizedTest is Test {
     {
         return _isOptimizedTest()
             ? ModularAccount(
-                payable(
-                    deployCode(
+                payable(deployCode(
                         "out-optimized/ModularAccount.sol/ModularAccount.json",
                         abi.encode(entryPoint, executionInstallDelegate)
-                    )
-                )
+                    ))
             )
             : new ModularAccount(entryPoint, executionInstallDelegate);
     }
@@ -69,12 +67,10 @@ abstract contract OptimizedTest is Test {
     ) internal returns (SemiModularAccountBytecode) {
         return _isOptimizedTest()
             ? SemiModularAccountBytecode(
-                payable(
-                    deployCode(
+                payable(deployCode(
                         "out-optimized/SemiModularAccountBytecode.sol/SemiModularAccountBytecode.json",
                         abi.encode(entryPoint, executionInstallDelegate)
-                    )
-                )
+                    ))
             )
             : new SemiModularAccountBytecode(entryPoint, executionInstallDelegate);
     }


### PR DESCRIPTION
## Motivation

Latest foundry changes result in linting issues from downcasting, even though it is acknowledged in the source.

Additionally, latest foundry changes include some minor naming changes.

## Solution

Update deprecated `deny_warnings = true` to `deny = 'warnings'`.

Add `--md` to the sizes command to format as markdown

Exclude `unsafe-typecast` from lints.
