### PR TITLE
feat: implement ERC-7821 minimal batch executor interface

### DIFF
--- a/src/account/ModularAccountBase.sol
+++ b/src/account/ModularAccountBase.sol
@@ -43,6 +43,7 @@ import {UUPSUpgradeable} from "solady/utils/UUPSUpgradeable.sol";
 
 import {ExecutionInstallDelegate} from "../helpers/ExecutionInstallDelegate.sol";
 import {_coalescePreValidation, _coalesceValidation} from "../helpers/ValidationResHelpers.sol";
+import {IERC7821} from "../interfaces/IERC7821.sol";
 import {IModularAccountBase} from "../interfaces/IModularAccountBase.sol";
 import {
     DensePostHookData,
@@ -69,6 +70,7 @@ import {TokenReceiver} from "./TokenReceiver.sol";
 abstract contract ModularAccountBase is
     IModularAccount,
     IModularAccountBase,
+    IERC7821,
     ModularAccountView,
     AccountStorageInitializable,
     AccountBase,
@@ -111,6 +113,7 @@ abstract contract ModularAccountBase is
     error CreateFailed();
     error DeferredActionSignatureInvalid();
     error RequireUserOperationContext();
+    error UnsupportedExecutionMode();
     error SelfCallRecursionDepthExceeded();
     error SignatureValidationInvalid(ModuleEntity validationFunction);
     error UserOpValidationInvalid(ModuleEntity validationFunction);
@@ -263,6 +266,35 @@ abstract contract ModularAccountBase is
         }
     }
 
+    /// @inheritdoc IERC7821
+    /// @notice May be validated by a global validation.
+    function execute(bytes32 mode, bytes calldata executionData) external payable override wrapNativeFunction {
+        uint256 id = _executionModeId(mode);
+        if (id == 0) {
+            revert UnsupportedExecutionMode();
+        }
+
+        // Both mode 1 (no opData) and mode 2 (optional opData) encode Call[] as the first ABI parameter.
+        // abi.decode handles both abi.encode(Call[]) and abi.encode(Call[], bytes) correctly because
+        // decoding a single parameter follows the offset to the array data regardless of trailing data.
+        Call[] memory calls = abi.decode(executionData, (Call[]));
+
+        uint256 callsLength = calls.length;
+        for (uint256 i = 0; i < callsLength; ++i) {
+            address target = calls[i].target;
+            // Per ERC-7821: address(0) is replaced with address(this).
+            if (target == address(0)) {
+                target = address(this);
+            }
+            ExecutionLib.callBubbleOnRevert(target, calls[i].value, calls[i].data);
+        }
+    }
+
+    /// @inheritdoc IERC7821
+    function supportsExecutionMode(bytes32 mode) external pure override returns (bool) {
+        return _executionModeId(mode) != 0;
+    }
+
     /// @inheritdoc IModularAccount
     function executeWithRuntimeValidation(bytes calldata data, bytes calldata authorization)
         external
@@ -372,7 +404,7 @@ abstract contract ModularAccountBase is
         }
         if (
             interfaceId == type(IERC721Receiver).interfaceId || interfaceId == type(IERC1155Receiver).interfaceId
-                || interfaceId == type(IERC165).interfaceId
+                || interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC7821).interfaceId
         ) {
             return true;
         }
@@ -397,6 +429,19 @@ abstract contract ModularAccountBase is
     }
 
     // INTERNAL FUNCTIONS
+
+    /// @dev Returns the execution mode id for the given mode, or 0 if unsupported.
+    /// Mode byte layout: [0] call type, [1] revert behavior, [2..5] reserved, [6..9] mode selector, [10..31] free.
+    function _executionModeId(bytes32 mode) internal pure returns (uint256 id) {
+        assembly ("memory-safe") {
+            // Extract bytes [0..1] and [6..9], masking out [2..5] (reserved) and [10..31] (free).
+            let m := and(shr(176, mode), 0xffff00000000ffffffff)
+            switch m
+            case 0x01000000000000000000 { id := 1 } // Batch call, no opData.
+            case 0x01000000000078210001 { id := 2 } // Batch call, optional opData.
+            default { id := 0 }
+        }
+    }
 
     // Parent function validateUserOp enforces that this call can only be made by the EntryPoint
     function _validateUserOp(PackedUserOperation calldata userOp, bytes32 userOpHash)
@@ -1042,7 +1087,11 @@ abstract contract ModularAccountBase is
                     selector := shr(224, calldataload(dataOffset))
                 }
 
-                if (selector == uint32(this.execute.selector) || selector == uint32(this.executeBatch.selector)) {
+                if (
+                    selector == uint32(IModularAccount.execute.selector)
+                        || selector == uint32(IModularAccount.executeBatch.selector)
+                        || selector == uint32(IERC7821.execute.selector)
+                ) {
                     // To prevent arbitrarily-deep recursive checking, we limit the depth of self-calls to one
                     // for the purposes of batching.
                     // This means that all self-calls must occur at the top level of the batch.

--- a/src/account/ModularAccountView.sol
+++ b/src/account/ModularAccountView.sol
@@ -34,6 +34,7 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeab
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
+import {IERC7821} from "../interfaces/IERC7821.sol";
 import {IModularAccountBase} from "../interfaces/IModularAccountBase.sol";
 import {MemManagementLib} from "../libraries/MemManagementLib.sol";
 import {ValidationLocatorLib} from "../libraries/ValidationLocatorLib.sol";
@@ -101,6 +102,7 @@ abstract contract ModularAccountView is IModularAccountView {
                 || selector == uint32(IERC1271.isValidSignature.selector)
                 || selector == uint32(IERC165.supportsInterface.selector)
                 || selector == uint32(IERC721Receiver.onERC721Received.selector)
+                || selector == uint32(IERC7821.supportsExecutionMode.selector)
                 || selector == uint32(IModularAccount.accountId.selector)
                 || selector == uint32(IModularAccountView.getExecutionData.selector)
                 || selector == uint32(IModularAccountView.getValidationData.selector)
@@ -118,6 +120,7 @@ abstract contract ModularAccountView is IModularAccountView {
     function _isWrappedNativeFunction(uint32 selector) internal pure virtual returns (bool) {
         return (selector == uint32(IModularAccount.execute.selector)
                 || selector == uint32(IModularAccount.executeBatch.selector)
+                || selector == uint32(IERC7821.execute.selector)
                 || selector == uint32(IModularAccount.installExecution.selector)
                 || selector == uint32(IModularAccount.installValidation.selector)
                 || selector == uint32(IModularAccount.uninstallExecution.selector)

--- a/src/interfaces/IERC7821.sol
+++ b/src/interfaces/IERC7821.sol
@@ -1,0 +1,33 @@
+// This file is part of Modular Account.
+//
+// Copyright 2024 Alchemy Insights, Inc.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+// Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with this program. If not, see
+// <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.28;
+
+/// @title IERC7821
+/// @notice Minimal Batch Executor Interface (ERC-7821)
+interface IERC7821 {
+    /// @dev Executes the calls in `executionData`.
+    /// Reverts and bubbles up error if any call fails.
+    /// @param mode The execution mode, encoded as a bytes32.
+    /// @param executionData The ABI-encoded batch call data.
+    function execute(bytes32 mode, bytes calldata executionData) external payable;
+
+    /// @dev Returns whether the execution mode is supported.
+    /// @param mode The execution mode to check.
+    /// @return Whether the mode is supported.
+    function supportsExecutionMode(bytes32 mode) external view returns (bool);
+}

--- a/test/account/AccountReturnData.t.sol
+++ b/test/account/AccountReturnData.t.sol
@@ -81,7 +81,7 @@ contract AccountReturnDataTest is AccountTestBase {
     function test_returnData_singular_execute() public withSMATest {
         bytes memory returnData = account1.executeWithRuntimeValidation(
             abi.encodeCall(
-                account1.execute,
+                IModularAccount.execute,
                 (address(regularResultContract), 0, abi.encodeCall(RegularResultContract.foo, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")

--- a/test/account/DeferredValidation.t.sol
+++ b/test/account/DeferredValidation.t.sol
@@ -49,7 +49,7 @@ contract DeferredValidationTest is AccountTestBase {
 
     function setUp() public override {
         _revertSnapshot = vm.snapshotState();
-        _encodedCall = abi.encodeCall(ModularAccountBase.execute, (makeAddr("dead"), 0 wei, ""));
+        _encodedCall = abi.encodeCall(IModularAccount.execute, (makeAddr("dead"), 0 wei, ""));
         _deferredValidation = ModuleEntityLib.pack(address(_deploySingleSignerValidationModule()), _NEW_ENTITY_ID);
 
         (address newSigner, uint256 newSignerKey) = makeAddrAndKey("newSigner");

--- a/test/account/ERC7821.t.sol
+++ b/test/account/ERC7821.t.sol
@@ -1,0 +1,218 @@
+// This file is part of Modular Account.
+//
+// Copyright 2024 Alchemy Insights, Inc.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+// Public License as published by the Free Software Foundation, either version 3 of the License, or (at your
+// option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with this program. If not, see
+// <https://www.gnu.org/licenses/>.
+
+pragma solidity ^0.8.28;
+
+import {Call, IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
+import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+import {ModularAccountBase} from "../../src/account/ModularAccountBase.sol";
+import {IERC7821} from "../../src/interfaces/IERC7821.sol";
+
+import {Counter} from "../mocks/Counter.sol";
+import {AccountTestBase} from "../utils/AccountTestBase.sol";
+
+contract ERC7821Test is AccountTestBase {
+    Counter public counter;
+    address public ethRecipient;
+
+    // ERC-7821 execution modes
+    bytes32 internal constant MODE_BATCH =
+        bytes32(uint256(0x0100000000000000000000000000000000000000000000000000000000000000));
+    bytes32 internal constant MODE_BATCH_OPDATA =
+        bytes32(uint256(0x0100000000007821000100000000000000000000000000000000000000000000));
+
+    function setUp() public override {
+        _revertSnapshot = vm.snapshotState();
+        counter = new Counter();
+        ethRecipient = makeAddr("ethRecipient");
+    }
+
+    // ──────────────────────────────────────────────
+    // supportsExecutionMode
+    // ──────────────────────────────────────────────
+
+    function test_supportsExecutionMode_batch() external view {
+        assertTrue(account1.supportsExecutionMode(MODE_BATCH));
+    }
+
+    function test_supportsExecutionMode_batchWithOpData() external view {
+        assertTrue(account1.supportsExecutionMode(MODE_BATCH_OPDATA));
+    }
+
+    function test_supportsExecutionMode_unsupported() external view {
+        // Single call mode (0x00...) is not supported
+        assertFalse(account1.supportsExecutionMode(bytes32(0)));
+        // Unsupported mode byte
+        assertFalse(account1.supportsExecutionMode(bytes32(uint256(1))));
+    }
+
+    function test_supportsExecutionMode_freeBytes() external view {
+        // Modes with non-zero free bytes [10..31] should still be supported
+        bytes32 modeWithFreeBytes = MODE_BATCH | bytes32(uint256(0xdeadbeef));
+        assertTrue(account1.supportsExecutionMode(modeWithFreeBytes));
+    }
+
+    // ──────────────────────────────────────────────
+    // supportsInterface
+    // ──────────────────────────────────────────────
+
+    function test_supportsInterface_erc7821() external withSMATest {
+        assertTrue(account1.supportsInterface(type(IERC7821).interfaceId));
+    }
+
+    // ──────────────────────────────────────────────
+    // execute via UserOp (mode 1: batch, no opData)
+    // ──────────────────────────────────────────────
+
+    function test_erc7821_singleCall_userOp() external withSMATest {
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({target: address(counter), value: 0, data: abi.encodeCall(Counter.increment, ())});
+
+        bytes memory executionData = abi.encode(calls);
+        _runUserOp(abi.encodeCall(IERC7821.execute, (MODE_BATCH, executionData)));
+
+        assertEq(counter.number(), 1);
+    }
+
+    function test_erc7821_batchCalls_userOp() external withSMATest {
+        Call[] memory calls = new Call[](3);
+        calls[0] = Call({target: address(counter), value: 0, data: abi.encodeCall(Counter.increment, ())});
+        calls[1] = Call({target: address(counter), value: 0, data: abi.encodeCall(Counter.increment, ())});
+        calls[2] = Call({target: address(counter), value: 0, data: abi.encodeCall(Counter.increment, ())});
+
+        bytes memory executionData = abi.encode(calls);
+        _runUserOp(abi.encodeCall(IERC7821.execute, (MODE_BATCH, executionData)));
+
+        assertEq(counter.number(), 3);
+    }
+
+    function test_erc7821_ethTransfer_userOp() external withSMATest {
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({target: ethRecipient, value: 1 ether, data: ""});
+
+        bytes memory executionData = abi.encode(calls);
+        _runUserOp(abi.encodeCall(IERC7821.execute, (MODE_BATCH, executionData)));
+
+        assertEq(ethRecipient.balance, 1 ether);
+    }
+
+    // ──────────────────────────────────────────────
+    // execute via UserOp (mode 2: batch with opData)
+    // ──────────────────────────────────────────────
+
+    function test_erc7821_mode2_userOp() external withSMATest {
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({target: address(counter), value: 0, data: abi.encodeCall(Counter.increment, ())});
+
+        // Mode 2 with opData
+        bytes memory executionData = abi.encode(calls, bytes("some opData"));
+        _runUserOp(abi.encodeCall(IERC7821.execute, (MODE_BATCH_OPDATA, executionData)));
+
+        assertEq(counter.number(), 1);
+    }
+
+    function test_erc7821_mode2_noOpData_userOp() external withSMATest {
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({target: address(counter), value: 0, data: abi.encodeCall(Counter.increment, ())});
+
+        // Mode 2 but without opData (just calls)
+        bytes memory executionData = abi.encode(calls);
+        _runUserOp(abi.encodeCall(IERC7821.execute, (MODE_BATCH_OPDATA, executionData)));
+
+        assertEq(counter.number(), 1);
+    }
+
+    // ──────────────────────────────────────────────
+    // address(0) replacement
+    // ──────────────────────────────────────────────
+
+    function test_erc7821_addressZeroReplacement_userOp() external withSMATest {
+        // address(0) in target should be replaced with address(this) i.e. the account
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({target: address(0), value: 0, data: abi.encodeCall(IModularAccount.accountId, ())});
+
+        bytes memory executionData = abi.encode(calls);
+        // Should not revert - calls account's own accountId()
+        _runUserOp(abi.encodeCall(IERC7821.execute, (MODE_BATCH, executionData)));
+    }
+
+    // ──────────────────────────────────────────────
+    // execute via runtime validation
+    // ──────────────────────────────────────────────
+
+    function test_erc7821_singleCall_runtime() external withSMATest {
+        Call[] memory calls = new Call[](1);
+        calls[0] = Call({target: address(counter), value: 0, data: abi.encodeCall(Counter.increment, ())});
+
+        bytes memory executionData = abi.encode(calls);
+        _runtimeCall(abi.encodeCall(IERC7821.execute, (MODE_BATCH, executionData)));
+
+        assertEq(counter.number(), 1);
+    }
+
+    function test_erc7821_batchCalls_runtime() external withSMATest {
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({target: address(counter), value: 0, data: abi.encodeCall(Counter.increment, ())});
+        calls[1] = Call({target: ethRecipient, value: 1 ether, data: ""});
+
+        bytes memory executionData = abi.encode(calls);
+        _runtimeCall(abi.encodeCall(IERC7821.execute, (MODE_BATCH, executionData)));
+
+        assertEq(counter.number(), 1);
+        assertEq(ethRecipient.balance, 1 ether);
+    }
+
+    // ──────────────────────────────────────────────
+    // reverts
+    // ──────────────────────────────────────────────
+
+    function test_erc7821_revert_unsupportedMode() external {
+        Call[] memory calls = new Call[](0);
+        bytes memory executionData = abi.encode(calls);
+
+        _runtimeCallExpFail(
+            abi.encodeCall(IERC7821.execute, (bytes32(0), executionData)),
+            abi.encodeWithSelector(ModularAccountBase.UnsupportedExecutionMode.selector)
+        );
+    }
+
+    function test_erc7821_revert_callFails_runtime() external withSMATest {
+        // Batch where the second call fails should revert atomically
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({target: address(counter), value: 0, data: abi.encodeCall(Counter.increment, ())});
+        // Second call sends more ETH than the account has
+        calls[1] = Call({target: ethRecipient, value: 200 ether, data: ""});
+
+        bytes memory executionData = abi.encode(calls);
+
+        // Should revert - the batch fails atomically. First call's effects are rolled back.
+        _runtimeCallExpFail(abi.encodeCall(IERC7821.execute, (MODE_BATCH, executionData)), "");
+
+        // Counter should not have been incremented (atomic revert)
+        assertEq(counter.number(), 0);
+    }
+
+    function test_erc7821_emptyCalls_userOp() external withSMATest {
+        // Empty calls array should succeed
+        Call[] memory calls = new Call[](0);
+        bytes memory executionData = abi.encode(calls);
+        _runUserOp(abi.encodeCall(IERC7821.execute, (MODE_BATCH, executionData)));
+    }
+}

--- a/test/account/GlobalValidationTest.t.sol
+++ b/test/account/GlobalValidationTest.t.sol
@@ -17,6 +17,7 @@
 
 pragma solidity ^0.8.28;
 
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
@@ -59,7 +60,7 @@ contract GlobalValidationTest is AccountTestBase {
                 address(factory),
                 abi.encodeCall(factory.createAccount, (owner2, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID))
             ),
-            callData: abi.encodeCall(ModularAccountBase.execute, (ethRecipient, 1 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -86,7 +87,7 @@ contract GlobalValidationTest is AccountTestBase {
 
         vm.prank(owner2);
         account2.executeWithRuntimeValidation(
-            abi.encodeCall(ModularAccountBase.execute, (ethRecipient, 1 wei, "")),
+            abi.encodeCall(IModularAccount.execute, (ethRecipient, 1 wei, "")),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
 
@@ -121,7 +122,7 @@ contract GlobalValidationTest is AccountTestBase {
                 address(factory),
                 abi.encodeCall(factory.createAccount, (owner2, 0, TEST_DEFAULT_VALIDATION_ENTITY_ID))
             ),
-            callData: abi.encodeCall(ModularAccountBase.execute, (ethRecipient, 1 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -143,7 +144,7 @@ contract GlobalValidationTest is AccountTestBase {
                 0,
                 "AA23 reverted",
                 abi.encodeWithSelector(
-                    ModularAccountBase.ValidationFunctionMissing.selector, ModularAccountBase.execute.selector
+                    ModularAccountBase.ValidationFunctionMissing.selector, IModularAccount.execute.selector
                 )
             )
         );

--- a/test/account/HookOrdering.t.sol
+++ b/test/account/HookOrdering.t.sol
@@ -22,7 +22,11 @@ import {
     ExecutionManifest,
     ManifestExecutionHook
 } from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
-import {ModuleEntity, ValidationConfig} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {
+    IModularAccount,
+    ModuleEntity,
+    ValidationConfig
+} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "@erc6900/reference-implementation/libraries/ValidationConfigLib.sol";
@@ -227,7 +231,7 @@ contract HookOrderingTest is AccountTestBase {
             callData: abi.encodePacked(
                 account1.executeUserOp.selector,
                 abi.encodeCall(
-                    account1.execute,
+                    IModularAccount.execute,
                     (address(hookOrderChecker), 0 wei, abi.encodeCall(HookOrderCheckerModule.foo, (17)))
                 )
             ),
@@ -254,7 +258,7 @@ contract HookOrderingTest is AccountTestBase {
             nonce: _encodeNonce(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_V, 0),
             initCode: hex"",
             callData: abi.encodeCall(
-                account1.execute,
+                IModularAccount.execute,
                 (address(hookOrderChecker), 0 wei, abi.encodeCall(HookOrderCheckerModule.foo, (17)))
             ),
             accountGasLimits: _encodeGas(1_000_000, 1_000_000),
@@ -282,7 +286,7 @@ contract HookOrderingTest is AccountTestBase {
             callData: abi.encodePacked(
                 account1.executeUserOp.selector,
                 abi.encodeCall(
-                    account1.execute,
+                    IModularAccount.execute,
                     (address(hookOrderChecker), 0 wei, abi.encodeCall(HookOrderCheckerModule.foo, (17)))
                 )
             ),
@@ -306,7 +310,7 @@ contract HookOrderingTest is AccountTestBase {
 
         account1.executeWithRuntimeValidation(
             abi.encodeCall(
-                account1.execute,
+                IModularAccount.execute,
                 (address(hookOrderChecker), 0 wei, abi.encodeCall(HookOrderCheckerModule.foo, (17)))
             ),
             _encodeSignature(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_VALIDATION, "")
@@ -320,7 +324,7 @@ contract HookOrderingTest is AccountTestBase {
 
         account1.executeWithRuntimeValidation(
             abi.encodeCall(
-                account1.execute,
+                IModularAccount.execute,
                 (address(hookOrderChecker), 0 wei, abi.encodeCall(HookOrderCheckerModule.foo, (17)))
             ),
             _encodeSignature(orderCheckerValidationEntity, SELECTOR_ASSOCIATED_VALIDATION, "")
@@ -470,22 +474,22 @@ contract HookOrderingTest is AccountTestBase {
 
         // Apply hooks to the `execute` function
         execHooks[6] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector, entityId: 11, isPreHook: true, isPostHook: false
+            executionSelector: IModularAccount.execute.selector, entityId: 11, isPreHook: true, isPostHook: false
         });
         execHooks[7] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector, entityId: 12, isPreHook: false, isPostHook: true
+            executionSelector: IModularAccount.execute.selector, entityId: 12, isPreHook: false, isPostHook: true
         });
         execHooks[8] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector, entityId: 13, isPreHook: true, isPostHook: true
+            executionSelector: IModularAccount.execute.selector, entityId: 13, isPreHook: true, isPostHook: true
         });
         execHooks[9] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector, entityId: 14, isPreHook: true, isPostHook: true
+            executionSelector: IModularAccount.execute.selector, entityId: 14, isPreHook: true, isPostHook: true
         });
         execHooks[10] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector, entityId: 15, isPreHook: true, isPostHook: false
+            executionSelector: IModularAccount.execute.selector, entityId: 15, isPreHook: true, isPostHook: false
         });
         execHooks[11] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector, entityId: 16, isPreHook: false, isPostHook: true
+            executionSelector: IModularAccount.execute.selector, entityId: 16, isPreHook: false, isPostHook: true
         });
 
         manifest.executionHooks = execHooks;
@@ -510,7 +514,7 @@ contract HookOrderingTest is AccountTestBase {
 
         bytes4[] memory selectors = new bytes4[](2);
         selectors[0] = HookOrderCheckerModule.foo.selector;
-        selectors[1] = account1.execute.selector;
+        selectors[1] = IModularAccount.execute.selector;
 
         bytes[] memory hooks = new bytes[](3);
 

--- a/test/account/ModularAccount.t.sol
+++ b/test/account/ModularAccount.t.sol
@@ -24,7 +24,7 @@ import {
     ExecutionManifest,
     ManifestExecutionHook
 } from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
-import {Call} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {Call, IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {ExecutionDataView} from "@erc6900/reference-implementation/interfaces/IModularAccountView.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "@erc6900/reference-implementation/libraries/ValidationConfigLib.sol";
@@ -99,7 +99,7 @@ contract ModularAccountTest is AccountTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: "",
-            callData: abi.encodeCall(ModularAccountBase.execute, (ethRecipient, 1 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -126,7 +126,7 @@ contract ModularAccountTest is AccountTestBase {
                 SemiModularAccountBytecode(payable(account1)).updateFallbackSignerData, (owner2, false)
             )
             : abi.encodeCall(
-                ModularAccountBase.execute,
+                IModularAccount.execute,
                 (
                     address(singleSignerValidationModule),
                     0,
@@ -180,7 +180,7 @@ contract ModularAccountTest is AccountTestBase {
             sender: address(account2),
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: initCode,
-            callData: abi.encodeCall(ModularAccountBase.execute, (recipient, 1 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (recipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -206,7 +206,7 @@ contract ModularAccountTest is AccountTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: "",
-            callData: abi.encodeCall(ModularAccountBase.execute, (ethRecipient, 1 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -238,7 +238,7 @@ contract ModularAccountTest is AccountTestBase {
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: "",
             callData: abi.encodeCall(
-                ModularAccountBase.execute, (address(counter), 0, abi.encodeCall(counter.increment, ()))
+                IModularAccount.execute, (address(counter), 0, abi.encodeCall(counter.increment, ()))
             ),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
@@ -510,7 +510,7 @@ contract ModularAccountTest is AccountTestBase {
                 ModuleEntityLib.pack(address(singleSignerValidationModule), newEntityId), GLOBAL_V, 0
             ),
             initCode: "",
-            callData: abi.encodeCall(ModularAccountBase.execute, (ethRecipient, 1 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (ethRecipient, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -542,7 +542,7 @@ contract ModularAccountTest is AccountTestBase {
         //show working rt validation
         vm.startPrank(address(owner1));
         account1.executeWithRuntimeValidation(
-            abi.encodeCall(ModularAccountBase.execute, (ethRecipient, 1 wei, "")),
+            abi.encodeCall(IModularAccount.execute, (ethRecipient, 1 wei, "")),
             _encodeSignature(
                 ModuleEntityLib.pack(address(singleSignerValidationModule), newEntityId), GLOBAL_VALIDATION, ""
             )
@@ -640,7 +640,7 @@ contract ModularAccountTest is AccountTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: "",
-            callData: abi.encodePacked(bytes3(ModularAccountBase.execute.selector)), // Short calldata
+            callData: abi.encodePacked(bytes3(IModularAccount.execute.selector)), // Short calldata
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -663,7 +663,7 @@ contract ModularAccountTest is AccountTestBase {
                 "AA23 reverted",
                 abi.encodeWithSelector(
                     ModularAccountBase.UnrecognizedFunction.selector,
-                    bytes4(bytes3(ModularAccountBase.execute.selector))
+                    bytes4(bytes3(IModularAccount.execute.selector))
                 )
             )
         );
@@ -683,7 +683,7 @@ contract ModularAccountTest is AccountTestBase {
         ExecutionManifest memory m;
         m.executionHooks = new ManifestExecutionHook[](1);
         m.executionHooks[0] = ManifestExecutionHook({
-            executionSelector: account1.execute.selector, entityId: 0, isPreHook: true, isPostHook: false
+            executionSelector: IModularAccount.execute.selector, entityId: 0, isPreHook: true, isPostHook: false
         });
 
         vm.prank(address(entryPoint));
@@ -693,13 +693,18 @@ contract ModularAccountTest is AccountTestBase {
             address(mockedModule),
             abi.encodeCall(
                 IExecutionHookModule.preExecutionHook,
-                (0, address(account1), 0.5 ether, abi.encodeCall(account1.execute, (ethRecipient, 1 wei, "")))
+                (
+                    0,
+                    address(account1),
+                    0.5 ether,
+                    abi.encodeCall(IModularAccount.execute, (ethRecipient, 1 wei, ""))
+                )
             )
         );
         vm.deal(address(owner1), 1 ether);
         vm.prank(owner1);
         account1.executeWithRuntimeValidation{value: 0.5 ether}(
-            abi.encodeCall(ModularAccountBase.execute, (ethRecipient, 1 wei, "")),
+            abi.encodeCall(IModularAccount.execute, (ethRecipient, 1 wei, "")),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
     }

--- a/test/account/MultiValidation.t.sol
+++ b/test/account/MultiValidation.t.sol
@@ -102,7 +102,7 @@ contract MultiValidationTest is AccountTestBase {
             sender: address(account1),
             nonce: _encodeNonce(ModuleEntityLib.pack(address(validator2), ENTITY_ID_1), GLOBAL_V, 0),
             initCode: "",
-            callData: abi.encodeCall(ModularAccountBase.execute, (CODELESS_ADDRESS, 0, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (CODELESS_ADDRESS, 0, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),

--- a/test/account/PHCallBuffers.t.sol
+++ b/test/account/PHCallBuffers.t.sol
@@ -23,6 +23,7 @@ import {
     ExecutionManifest,
     ManifestExecutionHook
 } from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
 import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
 import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
@@ -74,7 +75,8 @@ contract PHCallBufferTest is AccountTestBase {
             nonce: _encodeNonce(_validationFunction, GLOBAL_V, 0),
             initCode: "",
             callData: abi.encodePacked(
-                IAccountExecute.executeUserOp.selector, abi.encodeCall(account1.execute, (beneficiary, 0 wei, ""))
+                IAccountExecute.executeUserOp.selector,
+                abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, ""))
             ),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
@@ -115,7 +117,7 @@ contract PHCallBufferTest is AccountTestBase {
         _allowTestDirectCalls();
         _install3ValAssocExecHooks();
 
-        bytes memory callData = abi.encodeCall(account1.execute, (beneficiary, 0 wei, ""));
+        bytes memory callData = abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, ""));
         bytes memory authorization = _encodeSignature(_validationFunction, GLOBAL_VALIDATION, "");
 
         // Line up the "expect emit" calls
@@ -143,7 +145,7 @@ contract PHCallBufferTest is AccountTestBase {
         _install3ValAssocExecHooks();
 
         bytes memory callData =
-            abi.encodePacked(abi.encodeCall(account1.execute, (beneficiary, 0 wei, "")), "abcdefghijk");
+            abi.encodePacked(abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, "")), "abcdefghijk");
         bytes memory authorization = _encodeSignature(_validationFunction, GLOBAL_VALIDATION, "");
 
         // Line up the "expect emit" calls
@@ -167,7 +169,7 @@ contract PHCallBufferTest is AccountTestBase {
         _install3ValAssocExecHooks();
         _addPreRuntimeValidationHook();
 
-        bytes memory callData = abi.encodeCall(account1.execute, (beneficiary, 0 wei, ""));
+        bytes memory callData = abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, ""));
         bytes memory authorization = _encodeSignature(_validationFunction, GLOBAL_VALIDATION, "");
 
         // pre RT validation expect emit
@@ -201,7 +203,7 @@ contract PHCallBufferTest is AccountTestBase {
         _addPreRuntimeValidationHook();
 
         bytes memory callData =
-            abi.encodePacked(abi.encodeCall(account1.execute, (beneficiary, 0 wei, "")), "abcdefghijk");
+            abi.encodePacked(abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, "")), "abcdefghijk");
         bytes memory authorization = _encodeSignature(_validationFunction, GLOBAL_VALIDATION, "");
 
         // pre RT validation expect emit
@@ -232,7 +234,7 @@ contract PHCallBufferTest is AccountTestBase {
     function test_preExecHooksWithRtValidation_reuseRTOnlyBuffer_regularCallData() public withSMATest {
         _install3ValAssocExecHooks();
 
-        bytes memory callData = abi.encodeCall(account1.execute, (beneficiary, 0 wei, ""));
+        bytes memory callData = abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, ""));
         bytes memory authorization = _encodeSignature(_validationFunction, GLOBAL_VALIDATION, "");
 
         // RT validation emit, only if not SMA
@@ -266,7 +268,7 @@ contract PHCallBufferTest is AccountTestBase {
         _install3ValAssocExecHooks();
 
         bytes memory callData =
-            abi.encodePacked(abi.encodeCall(account1.execute, (beneficiary, 0 wei, "")), "abcdefghijk");
+            abi.encodePacked(abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, "")), "abcdefghijk");
         bytes memory authorization = _encodeSignature(_validationFunction, GLOBAL_VALIDATION, "");
 
         // RT validation emit, only if not SMA
@@ -300,7 +302,7 @@ contract PHCallBufferTest is AccountTestBase {
         _install3ValAssocExecHooks();
         _addPreRuntimeValidationHook();
 
-        bytes memory callData = abi.encodeCall(account1.execute, (beneficiary, 0 wei, ""));
+        bytes memory callData = abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, ""));
         bytes memory authorization = _encodeSignature(_validationFunction, GLOBAL_VALIDATION, "");
 
         // pre RT validation emit
@@ -344,7 +346,7 @@ contract PHCallBufferTest is AccountTestBase {
         _addPreRuntimeValidationHook();
 
         bytes memory callData =
-            abi.encodePacked(abi.encodeCall(account1.execute, (beneficiary, 0 wei, "")), "abcdefghijk");
+            abi.encodePacked(abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, "")), "abcdefghijk");
         bytes memory authorization = _encodeSignature(_validationFunction, GLOBAL_VALIDATION, "");
 
         // pre RT validation emit
@@ -388,7 +390,7 @@ contract PHCallBufferTest is AccountTestBase {
     function test_preExecHooks_EPCall_regularCallData() public withSMATest {
         _install3SelAssocExecHooks();
 
-        bytes memory callData = abi.encodeCall(account1.execute, (beneficiary, 0 wei, ""));
+        bytes memory callData = abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, ""));
 
         // Line up the "expect emit" calls
         for (uint256 i = 0; i < 3; i++) {
@@ -411,7 +413,7 @@ contract PHCallBufferTest is AccountTestBase {
         _install3SelAssocExecHooks();
 
         bytes memory callData =
-            abi.encodePacked(abi.encodeCall(account1.execute, (beneficiary, 0 wei, "")), "abcdefghijk");
+            abi.encodePacked(abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, "")), "abcdefghijk");
 
         // Line up the "expect emit" calls
         for (uint256 i = 0; i < 3; i++) {
@@ -435,7 +437,7 @@ contract PHCallBufferTest is AccountTestBase {
         _install3ValAssocExecHooks(DIRECT_CALL_VALIDATION_ENTITY_ID, true);
         _addPreRuntimeValidationHook();
 
-        bytes memory callData = abi.encodeCall(account1.execute, (beneficiary, 0 wei, ""));
+        bytes memory callData = abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, ""));
 
         // pre RT validation emit
         vm.expectEmit(address(preValidationHook));
@@ -537,7 +539,7 @@ contract PHCallBufferTest is AccountTestBase {
 
             m.executionHooks = new ManifestExecutionHook[](1);
             m.executionHooks[0] = ManifestExecutionHook({
-                executionSelector: account1.execute.selector,
+                executionSelector: IModularAccount.execute.selector,
                 entityId: uint32(i),
                 isPreHook: true,
                 isPostHook: false

--- a/test/account/PerHookData.t.sol
+++ b/test/account/PerHookData.t.sol
@@ -17,7 +17,7 @@
 
 pragma solidity ^0.8.28;
 
-import {ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IModularAccount, ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {SparseCalldataSegmentLib} from "@erc6900/reference-implementation/libraries/SparseCalldataSegmentLib.sol";
@@ -207,7 +207,7 @@ contract PerHookDataTest is CustomValidationTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: "",
-            callData: abi.encodeCall(ModularAccountBase.execute, (beneficiary, 1 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (beneficiary, 1 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -273,7 +273,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         vm.prank(owner1);
         account1.executeWithRuntimeValidation(
             abi.encodeCall(
-                ModularAccountBase.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                IModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
@@ -297,7 +297,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         );
         account1.executeWithRuntimeValidation(
             abi.encodeCall(
-                ModularAccountBase.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                IModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
@@ -314,7 +314,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         );
         account1.executeWithRuntimeValidation(
             abi.encodeCall(
-                ModularAccountBase.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                IModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
@@ -331,7 +331,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         );
         account1.executeWithRuntimeValidation(
             abi.encodeCall(
-                ModularAccountBase.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                IModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
@@ -349,7 +349,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         vm.prank(owner1);
         account1.executeWithRuntimeValidation(
             abi.encodeCall(
-                ModularAccountBase.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                IModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
@@ -368,7 +368,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         vm.expectRevert(abi.encodeWithSelector(SparseCalldataSegmentLib.SegmentOutOfOrder.selector));
         account1.executeWithRuntimeValidation(
             abi.encodeCall(
-                ModularAccountBase.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                IModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
@@ -387,7 +387,7 @@ contract PerHookDataTest is CustomValidationTestBase {
             )
         );
         account1.executeWithRuntimeValidation(
-            abi.encodeCall(ModularAccountBase.execute, (beneficiary, 1 wei, "")),
+            abi.encodeCall(IModularAccount.execute, (beneficiary, 1 wei, "")),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
     }
@@ -400,7 +400,7 @@ contract PerHookDataTest is CustomValidationTestBase {
         vm.expectRevert(abi.encodeWithSelector(SparseCalldataSegmentLib.NonCanonicalEncoding.selector));
         account1.executeWithRuntimeValidation(
             abi.encodeCall(
-                ModularAccountBase.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                IModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, preValidationHookData, "")
         );
@@ -492,7 +492,7 @@ contract PerHookDataTest is CustomValidationTestBase {
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: "",
             callData: abi.encodeCall(
-                ModularAccountBase.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
+                IModularAccount.execute, (address(_counter), 0 wei, abi.encodeCall(Counter.increment, ()))
             ),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,

--- a/test/account/PostHookData.t.sol
+++ b/test/account/PostHookData.t.sol
@@ -19,6 +19,7 @@ pragma solidity ^0.8.28;
 
 import {IExecutionHookModule} from "@erc6900/reference-implementation/interfaces/IExecutionHookModule.sol";
 import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {HookConfig, HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
 import {ModuleEntity, ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "@erc6900/reference-implementation/libraries/ValidationConfigLib.sol";
@@ -60,7 +61,8 @@ contract PostHookDataTest is AccountTestBase {
             nonce: _encodeNonce(_validationFunction, GLOBAL_V, 0),
             initCode: hex"",
             callData: abi.encodePacked(
-                IAccountExecute.executeUserOp.selector, abi.encodeCall(account1.execute, (beneficiary, 0, hex""))
+                IAccountExecute.executeUserOp.selector,
+                abi.encodeCall(IModularAccount.execute, (beneficiary, 0, hex""))
             ),
             accountGasLimits: _encodeGas(type(uint40).max, type(uint24).max),
             preVerificationGas: 0,
@@ -97,7 +99,7 @@ contract PostHookDataTest is AccountTestBase {
 
         _installValidationAndAssocHooks(fuzzConfig);
 
-        bytes memory callData = abi.encodeCall(account1.execute, (beneficiary, 0, hex""));
+        bytes memory callData = abi.encodeCall(IModularAccount.execute, (beneficiary, 0, hex""));
         bytes memory authorization = _encodeSignature(_validationFunction, GLOBAL_VALIDATION, "");
 
         _expectAndMockExecHooks(fuzzConfig, address(beneficiary), 0, callData);

--- a/test/account/RTCallBuffer.t.sol
+++ b/test/account/RTCallBuffer.t.sol
@@ -18,7 +18,7 @@
 pragma solidity ^0.8.28;
 
 import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
-
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
 import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
 import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
@@ -47,7 +47,7 @@ contract RTCallBufferTest is AccountTestBase {
     function test_multipleRTCalls() public withSMATest {
         _setup5ValidationHooks();
 
-        bytes memory callData = abi.encodeCall(account1.execute, (beneficiary, 0 wei, ""));
+        bytes memory callData = abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, ""));
         bytes memory authorization =
             _encodeSignature(_validationFunction, GLOBAL_VALIDATION, "abcdefghijklmnopqrstuvwxyz");
 
@@ -89,7 +89,7 @@ contract RTCallBufferTest is AccountTestBase {
     {
         _setup5ValidationHooks();
 
-        bytes memory callData = abi.encodeCall(account1.execute, (beneficiary, 0 wei, ""));
+        bytes memory callData = abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, ""));
 
         bytes[] memory hookDataDynamicArray = new bytes[](5);
         for (uint256 i = 0; i < 5; i++) {
@@ -167,7 +167,7 @@ contract RTCallBufferTest is AccountTestBase {
 
         _validationFunction = ModuleEntityLib.pack(address(validationModule), NEW_VALIDATION_ENTITY_ID);
 
-        bytes memory callData = abi.encodeCall(account1.execute, (beneficiary, 0 wei, ""));
+        bytes memory callData = abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, ""));
 
         // Set up the pre-validation hook data
         bytes[] memory hookDataDynamicArray = new bytes[](preValidationHookCount);

--- a/test/account/SMASpecific.t.sol
+++ b/test/account/SMASpecific.t.sol
@@ -17,7 +17,7 @@
 
 pragma solidity ^0.8.28;
 
-import {ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IModularAccount, ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "@erc6900/reference-implementation/libraries/ValidationConfigLib.sol";
@@ -90,7 +90,7 @@ contract SMASpecificTest is AccountTestBase {
         address target = CODELESS_ADDRESS;
         vm.prank(owner1);
         account1.executeWithRuntimeValidation(
-            abi.encodeCall(ModularAccountBase.execute, (target, transferAmount, "")),
+            abi.encodeCall(IModularAccount.execute, (target, transferAmount, "")),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
         assertEq(target.balance, transferAmount + initialBalance, "Target missing balance from runtime transfer");
@@ -105,10 +105,10 @@ contract SMASpecificTest is AccountTestBase {
         assertEq(target.balance, initialBalance, "Target has balance when it shouldn't");
 
         // Encode a transfer to the target.
-        // bytes memory encodedCall = abi.encodeCall(ModularAccountBase.execute, (target, transferAmount, ""));
+        // bytes memory encodedCall = abi.encodeCall(IModularAccount.execute, (target, transferAmount, ""));
         bytes memory encodedCall = abi.encodePacked(
             ModularAccountBase.executeUserOp.selector,
-            abi.encodeCall(ModularAccountBase.execute, (target, transferAmount, ""))
+            abi.encodeCall(IModularAccount.execute, (target, transferAmount, ""))
         );
 
         // Run a UO with the encoded call.

--- a/test/account/SelfCallAuthorization.t.sol
+++ b/test/account/SelfCallAuthorization.t.sol
@@ -102,7 +102,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         // Using global validation, self-call bypasses custom validation needed for ComprehensiveModule.foo
         _runUserOp(
             abi.encodeCall(
-                ModularAccountBase.execute, (address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()))
+                IModularAccount.execute, (address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()))
             ),
             abi.encodeWithSelector(
                 IEntryPoint.FailedOpWithRevert.selector,
@@ -134,7 +134,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
             abi.encodePacked(
                 IAccountExecute.executeUserOp.selector,
                 abi.encodeCall(
-                    ModularAccountBase.execute, (address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()))
+                    IModularAccount.execute, (address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()))
                 )
             ),
             abi.encodeWithSelector(
@@ -167,7 +167,7 @@ contract SelfCallAuthorizationTest is AccountTestBase {
         // Using global validation, self-call bypasses custom validation needed for ComprehensiveModule.foo
         _runtimeCall(
             abi.encodeCall(
-                ModularAccountBase.execute, (address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()))
+                IModularAccount.execute, (address(account1), 0, abi.encodeCall(ComprehensiveModule.foo, ()))
             ),
             abi.encodeWithSelector(ModularAccountBase.SelfCallRecursionDepthExceeded.selector)
         );

--- a/test/account/SemiModularAccountDirectCall.t.sol
+++ b/test/account/SemiModularAccountDirectCall.t.sol
@@ -18,7 +18,11 @@
 pragma solidity ^0.8.28;
 
 import {DIRECT_CALL_VALIDATION_ENTITY_ID} from "@erc6900/reference-implementation/helpers/Constants.sol";
-import {ModuleEntity, ValidationConfig} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {
+    IModularAccount,
+    ModuleEntity,
+    ValidationConfig
+} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "@erc6900/reference-implementation/libraries/ValidationConfigLib.sol";
@@ -55,7 +59,7 @@ contract SemiModularAccountDirectCallTest is AccountTestBase {
         SemiModularAccountBase(payable(account1)).updateFallbackSignerData(address(0), true);
 
         bytes memory expectedRevertData = abi.encodeWithSelector(
-            ModularAccountBase.ValidationFunctionMissing.selector, ModularAccountBase.execute.selector
+            ModularAccountBase.ValidationFunctionMissing.selector, IModularAccount.execute.selector
         );
 
         vm.prank(owner1);
@@ -65,7 +69,7 @@ contract SemiModularAccountDirectCallTest is AccountTestBase {
 
     function test_fail_smaDirectCall_notFallbackSigner() external {
         bytes memory expectedRevertData = abi.encodeWithSelector(
-            ModularAccountBase.ValidationFunctionMissing.selector, ModularAccountBase.execute.selector
+            ModularAccountBase.ValidationFunctionMissing.selector, IModularAccount.execute.selector
         );
 
         vm.prank(makeAddr("4546b"));

--- a/test/account/UOCallBuffer.t.sol
+++ b/test/account/UOCallBuffer.t.sol
@@ -18,6 +18,7 @@
 pragma solidity ^0.8.28;
 
 import {ExecutionManifest} from "@erc6900/reference-implementation/interfaces/IExecutionModule.sol";
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {IValidationHookModule} from "@erc6900/reference-implementation/interfaces/IValidationHookModule.sol";
 import {IValidationModule} from "@erc6900/reference-implementation/interfaces/IValidationModule.sol";
 import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
@@ -52,7 +53,7 @@ contract UOCallBufferTest is AccountTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_validationFunction, GLOBAL_V, 0),
             initCode: "",
-            callData: abi.encodeCall(account1.execute, (beneficiary, 0 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 2),
@@ -95,7 +96,7 @@ contract UOCallBufferTest is AccountTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_validationFunction, GLOBAL_V, 0),
             initCode: "",
-            callData: abi.encodeCall(account1.execute, (beneficiary, 0 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 2),
@@ -180,7 +181,7 @@ contract UOCallBufferTest is AccountTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_validationFunction, GLOBAL_V, 0),
             initCode: "",
-            callData: abi.encodeCall(account1.execute, (beneficiary, 0 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 2),
@@ -230,7 +231,7 @@ contract UOCallBufferTest is AccountTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_validationFunction, GLOBAL_V, 0),
             initCode: "",
-            callData: abi.encodeCall(account1.execute, (beneficiary, 0 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 2),
@@ -265,7 +266,7 @@ contract UOCallBufferTest is AccountTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: "",
-            callData: abi.encodeCall(account1.execute, (beneficiary, 0 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (beneficiary, 0 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 2),

--- a/test/account/UpgradeToSma.t.sol
+++ b/test/account/UpgradeToSma.t.sol
@@ -17,7 +17,7 @@
 
 pragma solidity ^0.8.28;
 
-import {ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {IModularAccount, ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {SimpleAccount} from "@eth-infinitism/account-abstraction/accounts/SimpleAccount.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
@@ -143,7 +143,7 @@ contract UpgradeToSmaTest is AccountTestBase {
         assertEq(target.balance, initialBalance, "Target has balance when it shouldn't");
 
         // Encode a transfer to the target.
-        bytes memory encodedCall = abi.encodeCall(ModularAccountBase.execute, (target, transferAmount, ""));
+        bytes memory encodedCall = abi.encodeCall(IModularAccount.execute, (target, transferAmount, ""));
 
         // Run a UO with the encoded call.
         if (withFallbackValidation) {

--- a/test/modules/AllowlistERC20TokenLimit.t.sol
+++ b/test/modules/AllowlistERC20TokenLimit.t.sol
@@ -104,7 +104,7 @@ contract AllowlistERC20TokenLimitTest is AccountTestBase {
 
     function _getExecuteWithSpend(uint256 value) internal view returns (bytes memory) {
         return abi.encodeCall(
-            ModularAccountBase.execute, (address(erc20), 0, abi.encodeCall(IERC20.transfer, (recipient, value)))
+            IModularAccount.execute, (address(erc20), 0, abi.encodeCall(IERC20.transfer, (recipient, value)))
         );
     }
 

--- a/test/modules/AllowlistModule.t.sol
+++ b/test/modules/AllowlistModule.t.sol
@@ -17,8 +17,11 @@
 
 pragma solidity ^0.8.28;
 
-import {ModuleEntity} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
-import {Call} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {
+    Call,
+    IModularAccount,
+    ModuleEntity
+} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {IEntryPoint} from "@eth-infinitism/account-abstraction/interfaces/IEntryPoint.sol";
@@ -138,7 +141,7 @@ contract AllowlistModuleTest is CustomValidationTestBase {
             HOOK_ENTITY_ID,
             address(0),
             0,
-            abi.encodeCall(ModularAccountBase.execute, (address(counters[1]), 1 wei, "")),
+            abi.encodeCall(IModularAccount.execute, (address(counters[1]), 1 wei, "")),
             ""
         );
     }
@@ -150,7 +153,7 @@ contract AllowlistModuleTest is CustomValidationTestBase {
 
         // verify case 1 - a selector (Counter.setNumber) + address (counters[0]) should match
         bytes memory data1 = abi.encodeCall(
-            ModularAccountBase.execute, (address(counters[0]), 0, abi.encodeCall(Counter.setNumber, (10)))
+            IModularAccount.execute, (address(counters[0]), 0, abi.encodeCall(Counter.setNumber, (10)))
         );
         allowlistModule.preRuntimeValidationHook(HOOK_ENTITY_ID, address(0), 0, data1, "");
         vm.expectRevert(abi.encodeWithSelector(AllowlistModule.AddressNotAllowed.selector));
@@ -160,7 +163,7 @@ contract AllowlistModuleTest is CustomValidationTestBase {
             address(0),
             0,
             abi.encodeCall(
-                ModularAccountBase.execute, (address(counters[5]), 0, abi.encodeCall(Counter.setNumber, (10)))
+                IModularAccount.execute, (address(counters[5]), 0, abi.encodeCall(Counter.setNumber, (10)))
             ),
             ""
         );
@@ -171,20 +174,20 @@ contract AllowlistModuleTest is CustomValidationTestBase {
             address(0),
             0,
             abi.encodeCall(
-                ModularAccountBase.execute, (address(counters[0]), 0, abi.encodeCall(Counter.decrement, ()))
+                IModularAccount.execute, (address(counters[0]), 0, abi.encodeCall(Counter.decrement, ()))
             ),
             ""
         );
 
         // verify case 2 - wildcard selector (Counter.increment), any address works
         bytes memory data2 = abi.encodeCall(
-            ModularAccountBase.execute, (address(allowlistModule), 0, abi.encodeCall(Counter.increment, ()))
+            IModularAccount.execute, (address(allowlistModule), 0, abi.encodeCall(Counter.increment, ()))
         );
         allowlistModule.preRuntimeValidationHook(HOOK_ENTITY_ID, address(0), 0, data2, "");
 
         // verify case 3 - wildcard address (counters[1]), any selector works
         bytes memory data3 = abi.encodeCall(
-            ModularAccountBase.execute,
+            IModularAccount.execute,
             (
                 address(counters[1]),
                 0,
@@ -278,7 +281,7 @@ contract AllowlistModuleTest is CustomValidationTestBase {
             nonce: _encodeNextNonce(address(account1), _signerValidation, true),
             initCode: hex"",
             callData: abi.encodeCall(
-                account1.execute, (address(counters[0]), 0, abi.encodeCall(Counter.increment, ()))
+                IModularAccount.execute, (address(counters[0]), 0, abi.encodeCall(Counter.increment, ()))
             ),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,

--- a/test/modules/NativeTokenLimitModule.t.sol
+++ b/test/modules/NativeTokenLimitModule.t.sol
@@ -80,7 +80,7 @@ contract NativeTokenLimitModuleTest is AccountTestBase {
     }
 
     function _getExecuteWithValue(uint256 value) internal view returns (bytes memory) {
-        return abi.encodeCall(ModularAccountBase.execute, (recipient, value, ""));
+        return abi.encodeCall(IModularAccount.execute, (recipient, value, ""));
     }
 
     function _getPerformCreateCalldata(uint256 value) internal pure returns (bytes memory) {

--- a/test/modules/PaymasterGuardModule.t.sol
+++ b/test/modules/PaymasterGuardModule.t.sol
@@ -17,6 +17,7 @@
 
 pragma solidity ^0.8.28;
 
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {HookConfigLib} from "@erc6900/reference-implementation/libraries/HookConfigLib.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "@erc6900/reference-implementation/libraries/ValidationConfigLib.sol";
@@ -155,7 +156,8 @@ contract PaymasterGuardModuleTest is AccountTestBase {
             ),
             initCode: "",
             callData: abi.encodePacked(
-                ModularAccountBase.executeUserOp.selector, abi.encodeCall(account1.execute, (owner1, 0, hex""))
+                ModularAccountBase.executeUserOp.selector,
+                abi.encodeCall(IModularAccount.execute, (owner1, 0, hex""))
             ),
             accountGasLimits: bytes32(bytes16(uint128(200_000))) | bytes32(uint256(200_000)),
             preVerificationGas: 200_000,

--- a/test/modules/TimeRangeModule.t.sol
+++ b/test/modules/TimeRangeModule.t.sol
@@ -17,7 +17,11 @@
 
 pragma solidity ^0.8.28;
 
-import {ModuleEntity, ValidationFlags} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
+import {
+    IModularAccount,
+    ModuleEntity,
+    ValidationFlags
+} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {
     HookConfig,
     ValidationDataView
@@ -157,7 +161,7 @@ contract TimeRangeModuleTest is CustomValidationTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: hex"",
-            callData: abi.encodeCall(ModularAccountBase.execute, (makeAddr("recipient"), 0 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (makeAddr("recipient"), 0 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -192,7 +196,7 @@ contract TimeRangeModuleTest is CustomValidationTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: hex"",
-            callData: abi.encodeCall(ModularAccountBase.execute, (makeAddr("recipient"), 0 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (makeAddr("recipient"), 0 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -227,7 +231,7 @@ contract TimeRangeModuleTest is CustomValidationTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: hex"",
-            callData: abi.encodeCall(ModularAccountBase.execute, (makeAddr("recipient"), 0 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (makeAddr("recipient"), 0 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),
@@ -268,7 +272,7 @@ contract TimeRangeModuleTest is CustomValidationTestBase {
         );
         vm.prank(owner1);
         account1.executeWithRuntimeValidation(
-            abi.encodeCall(ModularAccountBase.execute, (makeAddr("recipient"), 0 wei, "")),
+            abi.encodeCall(IModularAccount.execute, (makeAddr("recipient"), 0 wei, "")),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
     }
@@ -285,7 +289,7 @@ contract TimeRangeModuleTest is CustomValidationTestBase {
         vm.expectCall({callee: makeAddr("recipient"), msgValue: 0 wei, data: ""});
         vm.prank(owner1);
         account1.executeWithRuntimeValidation(
-            abi.encodeCall(ModularAccountBase.execute, (makeAddr("recipient"), 0 wei, "")),
+            abi.encodeCall(IModularAccount.execute, (makeAddr("recipient"), 0 wei, "")),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
     }
@@ -302,7 +306,7 @@ contract TimeRangeModuleTest is CustomValidationTestBase {
         vm.expectCall({callee: makeAddr("recipient"), msgValue: 0 wei, data: ""});
         vm.prank(owner1);
         account1.executeWithRuntimeValidation(
-            abi.encodeCall(ModularAccountBase.execute, (makeAddr("recipient"), 0 wei, "")),
+            abi.encodeCall(IModularAccount.execute, (makeAddr("recipient"), 0 wei, "")),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
     }
@@ -325,7 +329,7 @@ contract TimeRangeModuleTest is CustomValidationTestBase {
         );
         vm.prank(owner1);
         account1.executeWithRuntimeValidation(
-            abi.encodeCall(ModularAccountBase.execute, (makeAddr("recipient"), 0 wei, "")),
+            abi.encodeCall(IModularAccount.execute, (makeAddr("recipient"), 0 wei, "")),
             _encodeSignature(_signerValidation, GLOBAL_VALIDATION, "")
         );
     }
@@ -340,7 +344,7 @@ contract TimeRangeModuleTest is CustomValidationTestBase {
             sender: address(account1),
             nonce: _encodeNonce(_signerValidation, GLOBAL_V, 0),
             initCode: hex"",
-            callData: abi.encodeCall(ModularAccountBase.execute, (makeAddr("recipient"), 0 wei, "")),
+            callData: abi.encodeCall(IModularAccount.execute, (makeAddr("recipient"), 0 wei, "")),
             accountGasLimits: _encodeGas(VERIFICATION_GAS_LIMIT, CALL_GAS_LIMIT),
             preVerificationGas: 0,
             gasFees: _encodeGas(1, 1),

--- a/test/modules/WebAuthnValidationModule.t.sol
+++ b/test/modules/WebAuthnValidationModule.t.sol
@@ -17,6 +17,7 @@
 
 pragma solidity ^0.8.28;
 
+import {IModularAccount} from "@erc6900/reference-implementation/interfaces/IModularAccount.sol";
 import {ModuleEntityLib} from "@erc6900/reference-implementation/libraries/ModuleEntityLib.sol";
 import {ValidationConfigLib} from "@erc6900/reference-implementation/libraries/ValidationConfigLib.sol";
 import {PackedUserOperation} from "@eth-infinitism/account-abstraction/interfaces/PackedUserOperation.sol";
@@ -122,7 +123,7 @@ contract WebAuthnValidationModuleTest is AccountTestBase {
         PackedUserOperation memory uo;
         uo.sender = account;
         uo.nonce = _encodeNextNonce(account, ModuleEntityLib.pack(address(module), entityId), true);
-        uo.callData = abi.encodeCall(ModularAccountBase.execute, (CODELESS_ADDRESS, 0, new bytes(0)));
+        uo.callData = abi.encodeCall(IModularAccount.execute, (CODELESS_ADDRESS, 0, new bytes(0)));
         bytes32 uoHash = entryPoint.getUserOpHash(uo);
         uo.signature = _getUOSigForChallenge(uoHash, 0, 0);
 
@@ -134,7 +135,7 @@ contract WebAuthnValidationModuleTest is AccountTestBase {
         PackedUserOperation memory uo;
         uo.sender = account;
         uo.nonce = _encodeNextNonce(account, ModuleEntityLib.pack(address(module), entityId), true);
-        uo.callData = abi.encodeCall(ModularAccountBase.execute, (CODELESS_ADDRESS, 0, new bytes(0)));
+        uo.callData = abi.encodeCall(IModularAccount.execute, (CODELESS_ADDRESS, 0, new bytes(0)));
         bytes32 uoHash = entryPoint.getUserOpHash(uo);
 
         // make sure r, s values isn't the right one by accident. checking 1 should be enough

--- a/test/utils/AccountTestBase.sol
+++ b/test/utils/AccountTestBase.sol
@@ -302,7 +302,7 @@ abstract contract AccountTestBase is OptimizedTest, ModuleSignatureUtils {
 
         account1.executeWithRuntimeValidation(
             abi.encodeCall(
-                account1.execute,
+                IModularAccount.execute,
                 (
                     address(singleSignerValidationModule),
                     0,


### PR DESCRIPTION
## Summary
- Adds native ERC-7821 (`execute(bytes32,bytes)` + `supportsExecutionMode`) to `ModularAccountBase` for EIP-7702 compatibility
- Implemented as a native function with `wrapNativeFunction` to enforce validation/hooks for limited keys — cannot be a module due to security concerns with self-call permission enforcement
- Supports mode 1 (batch, no opData) and mode 2 (batch, optional opData), with `address(0)` → `address(this)` target replacement per spec
- ~960 bytes bytecode increase (~5%), well within Spurious Dragon limits
- Disambiguates `execute` overload references across test files (`ModularAccountBase.execute` → `IModularAccount.execute`)

## Test plan
- [x] 16 new tests in `ERC7821.t.sol` covering both modes, UserOp + runtime paths, address(0) replacement, reverts, empty batches, and `supportsInterface`/`supportsExecutionMode`
- [x] Full test suite passes (312/312)
- [x] `forge fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)